### PR TITLE
Fix firebase backend helpers

### DIFF
--- a/js/firebase.js
+++ b/js/firebase.js
@@ -130,6 +130,7 @@ export async function getDriveAccessTokenInteractive() {
 export async function signOutCurrent() {
   const auth = getAuthInstance();
   await signOut(auth);
+  driveAccessToken = null;
 }
 
 // --- Autenticación con correo y contraseña ---
@@ -434,7 +435,13 @@ export async function uploadMaterial({
       "Firebase Storage está deshabilitado. Usa addMaterialLink con un URL."
     );
   }
+  if (!file) {
+    throw new Error("Archivo requerido");
+  }
   const st = getStorageInstance();
+  if (!st) {
+    throw new Error("Firebase Storage no está inicializado");
+  }
   const db = getDb();
   const ts = Date.now();
   const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
@@ -502,6 +509,7 @@ export async function uploadMaterialToDrive({
   title,
   category,
   description,
+  ownerEmail,
   folderId = driveFolderId,
   onProgress,
 }) {
@@ -604,7 +612,10 @@ export async function uploadMaterialToDrive({
     description,
     url,
     path: null,
-    ownerEmail: auth?.currentUser?.email?.toLowerCase() || null,
+    ownerEmail:
+      ownerEmail?.toLowerCase() ||
+      auth?.currentUser?.email?.toLowerCase() ||
+      null,
     createdAt: serverTimestamp(),
     downloads: 0,
   });


### PR DESCRIPTION
## Summary
- Reset the cached Drive access token when signing out to avoid leaking scopes between sessions.
- Validate file input and storage availability before uploading Firebase materials.
- Preserve an explicit owner email when storing Drive-based materials.

## Testing
- No automated tests were run (not available in repository).


------
https://chatgpt.com/codex/tasks/task_e_68cda6a0db988325b6d08339e1dcc0a4