### PR TITLE
Handle attendance permissions for students

### DIFF
--- a/asistencia.html
+++ b/asistencia.html
@@ -519,7 +519,7 @@
     </script>
 
     <script type="module">
-      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, fetchAttendancesByDateRange } from './js/firebase.js';
+      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange } from './js/firebase.js';
       import { allowedEmailDomain } from './js/firebase-config.js';
 
       initFirebase();
@@ -541,6 +541,27 @@
         attendanceBtn.disabled = !enabled;
         attendanceBtn.style.opacity = enabled ? '1' : '0.6';
         attendanceBtn.style.cursor = enabled ? 'pointer' : 'not-allowed';
+      }
+
+      function syncAttendanceState(items) {
+        if (typeof window.setRegisteredAttendances === 'function') {
+          window.setRegisteredAttendances(items);
+        } else {
+          window.registeredAttendances = Array.isArray(items) ? items : [];
+        }
+        if (typeof window.updateAttendanceList === 'function') window.updateAttendanceList();
+        if (typeof window.updateAttendanceCount === 'function') window.updateAttendanceCount();
+      }
+
+      function applyRoleVisibility(role) {
+        const target = role === 'docente' ? 'docente' : 'estudiante';
+        try { localStorage.setItem('qs_role', target); } catch (_) {}
+        document.querySelectorAll('.teacher-only, .docente-only').forEach((el) => {
+          el.style.display = target === 'docente' ? '' : 'none';
+        });
+        document.querySelectorAll('.student-only, .estudiante-only').forEach((el) => {
+          el.style.display = target === 'docente' ? 'none' : '';
+        });
       }
 
       setAttendanceEnabled(false);
@@ -585,6 +606,7 @@
       let unsubscribeAttendance = null;
       onAuth(async (user) => {
         if (user && user.email?.toLowerCase().endsWith(`@${allowedEmailDomain}`)) {
+          const normalizedEmail = user.email.toLowerCase();
           userName.textContent = user.displayName || user.email;
           if (user.photoURL) {
             userPhoto.src = user.photoURL;
@@ -594,13 +616,16 @@
           }
           userInfo.classList.remove('hidden');
           if (signInBtn) signInBtn.classList.add('hidden');
-          const rosterEntry = (Array.isArray(window.students) ? window.students : []).find((student) => (student.email || '').toLowerCase() === user.email.toLowerCase());
-          if (rosterEntry?.type === 'teacher') {
-            try { localStorage.setItem('qs_role', 'docente'); } catch (_) {}
-            if (manualCard) {
-              manualCard.classList.remove('hidden');
-              manualCard.style.display = '';
-            }
+
+          const roster = Array.isArray(window.students) ? window.students : [];
+          const rosterEntry = roster.find((student) => (student.email || '').toLowerCase() === normalizedEmail);
+          const isTeacher = rosterEntry?.type === 'teacher';
+
+          applyRoleVisibility(isTeacher ? 'docente' : 'estudiante');
+
+          if (manualCard) {
+            manualCard.classList.toggle('hidden', !isTeacher);
+            manualCard.style.display = isTeacher ? '' : 'none';
           }
 
           const active = (typeof window.isClassActiveNow === 'function' ? window.isClassActiveNow() : true);
@@ -613,33 +638,43 @@
           window.__classActiveTimer = window.setInterval(() => {
             const activeNow = (typeof window.isClassActiveNow === 'function' ? window.isClassActiveNow() : true);
             setAttendanceEnabled(activeNow);
-            const banner = document.getElementById('classBanner');
-            if (banner) banner.classList.toggle('hidden', !activeNow);
+            const bannerNow = document.getElementById('classBanner');
+            if (bannerNow) bannerNow.classList.toggle('hidden', !activeNow);
           }, 60000);
 
           if (unsubscribeAttendance) unsubscribeAttendance();
-          unsubscribeAttendance = subscribeTodayAttendance((items) => {
-            if (typeof window.setRegisteredAttendances === 'function') {
-              window.setRegisteredAttendances(items);
-            } else {
-              window.registeredAttendances = items;
+          const handleSnapshot = (items) => {
+            syncAttendanceState(items);
+          };
+          const handleSubscriptionError = (error) => {
+            console.error('Attendance subscription error', error);
+            syncAttendanceState([]);
+            if (!isTeacher && !window.__attSubscriptionWarned) {
+              window.__attSubscriptionWarned = true;
+              alert('No se pudo consultar tu asistencia en línea por permisos insuficientes. Tu registro seguirá guardándose.');
             }
-            if (typeof window.updateAttendanceList === 'function') window.updateAttendanceList();
-            if (typeof window.updateAttendanceCount === 'function') window.updateAttendanceCount();
-          });
+          };
+          window.__attSubscriptionWarned = false;
+          try {
+            unsubscribeAttendance = isTeacher
+              ? subscribeTodayAttendance(handleSnapshot, handleSubscriptionError)
+              : subscribeTodayAttendanceByUser(normalizedEmail, handleSnapshot, handleSubscriptionError);
+          } catch (subscriptionError) {
+            handleSubscriptionError(subscriptionError);
+          }
         } else {
           userInfo.classList.add('hidden');
           if (signInBtn) signInBtn.classList.remove('hidden');
           setAttendanceEnabled(false);
+          applyRoleVisibility('estudiante');
           if (manualCard) {
             manualCard.classList.add('hidden');
             manualCard.style.display = 'none';
           }
           try { window.clearInterval(window.__classActiveTimer); } catch(_) {}
-          window.registeredAttendances = [];
-          if (typeof window.updateAttendanceList === 'function') window.updateAttendanceList();
-          if (typeof window.updateAttendanceCount === 'function') window.updateAttendanceCount();
+          syncAttendanceState([]);
           if (unsubscribeAttendance) { unsubscribeAttendance(); unsubscribeAttendance = null; }
+          window.__attSubscriptionWarned = false;
         }
       });
 


### PR DESCRIPTION
## Summary
- Suscribe los estudiantes únicamente a su propio listado de asistencias y ajusta la visibilidad de elementos según el rol, mostrando un aviso si Firestore bloquea la lectura global.
- Añade callbacks de error opcionales a las suscripciones de asistencias en Firebase para propagar mensajes de permisos insuficientes.

## Testing
- No automated tests were run (not available in repository).


------
https://chatgpt.com/codex/tasks/task_e_68cda6a0db988325b6d08339e1dcc0a4