### PR TITLE
Allow teachers to write manual attendance entries

### DIFF
--- a/asistencia.html
+++ b/asistencia.html
@@ -519,7 +519,7 @@
     </script>
 
     <script type="module">
-      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, fetchAttendancesByDateRange } from './js/firebase.js';
+      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange, ensureTeacherDocForUser } from './js/firebase.js';
       import { allowedEmailDomain } from './js/firebase-config.js';
 
       initFirebase();
@@ -541,6 +541,27 @@
         attendanceBtn.disabled = !enabled;
         attendanceBtn.style.opacity = enabled ? '1' : '0.6';
         attendanceBtn.style.cursor = enabled ? 'pointer' : 'not-allowed';
+      }
+
+      function syncAttendanceState(items) {
+        if (typeof window.setRegisteredAttendances === 'function') {
+          window.setRegisteredAttendances(items);
+        } else {
+          window.registeredAttendances = Array.isArray(items) ? items : [];
+        }
+        if (typeof window.updateAttendanceList === 'function') window.updateAttendanceList();
+        if (typeof window.updateAttendanceCount === 'function') window.updateAttendanceCount();
+      }
+
+      function applyRoleVisibility(role) {
+        const target = role === 'docente' ? 'docente' : 'estudiante';
+        try { localStorage.setItem('qs_role', target); } catch (_) {}
+        document.querySelectorAll('.teacher-only, .docente-only').forEach((el) => {
+          el.style.display = target === 'docente' ? '' : 'none';
+        });
+        document.querySelectorAll('.student-only, .estudiante-only').forEach((el) => {
+          el.style.display = target === 'docente' ? 'none' : '';
+        });
       }
 
       setAttendanceEnabled(false);
@@ -585,6 +606,7 @@
       let unsubscribeAttendance = null;
       onAuth(async (user) => {
         if (user && user.email?.toLowerCase().endsWith(`@${allowedEmailDomain}`)) {
+          const normalizedEmail = user.email.toLowerCase();
           userName.textContent = user.displayName || user.email;
           if (user.photoURL) {
             userPhoto.src = user.photoURL;
@@ -594,13 +616,28 @@
           }
           userInfo.classList.remove('hidden');
           if (signInBtn) signInBtn.classList.add('hidden');
-          const rosterEntry = (Array.isArray(window.students) ? window.students : []).find((student) => (student.email || '').toLowerCase() === user.email.toLowerCase());
-          if (rosterEntry?.type === 'teacher') {
-            try { localStorage.setItem('qs_role', 'docente'); } catch (_) {}
-            if (manualCard) {
-              manualCard.classList.remove('hidden');
-              manualCard.style.display = '';
+
+          const roster = Array.isArray(window.students) ? window.students : [];
+          const rosterEntry = roster.find((student) => (student.email || '').toLowerCase() === normalizedEmail);
+          const isTeacher = rosterEntry?.type === 'teacher';
+
+          if (isTeacher && user?.uid) {
+            try {
+              await ensureTeacherDocForUser({
+                uid: user.uid,
+                email: normalizedEmail,
+                displayName: user.displayName,
+              });
+            } catch (err) {
+              console.error('No se pudo preparar el perfil de docente en Firestore', err);
             }
+          }
+
+          applyRoleVisibility(isTeacher ? 'docente' : 'estudiante');
+
+          if (manualCard) {
+            manualCard.classList.toggle('hidden', !isTeacher);
+            manualCard.style.display = isTeacher ? '' : 'none';
           }
 
           const active = (typeof window.isClassActiveNow === 'function' ? window.isClassActiveNow() : true);
@@ -613,33 +650,43 @@
           window.__classActiveTimer = window.setInterval(() => {
             const activeNow = (typeof window.isClassActiveNow === 'function' ? window.isClassActiveNow() : true);
             setAttendanceEnabled(activeNow);
-            const banner = document.getElementById('classBanner');
-            if (banner) banner.classList.toggle('hidden', !activeNow);
+            const bannerNow = document.getElementById('classBanner');
+            if (bannerNow) bannerNow.classList.toggle('hidden', !activeNow);
           }, 60000);
 
           if (unsubscribeAttendance) unsubscribeAttendance();
-          unsubscribeAttendance = subscribeTodayAttendance((items) => {
-            if (typeof window.setRegisteredAttendances === 'function') {
-              window.setRegisteredAttendances(items);
-            } else {
-              window.registeredAttendances = items;
+          const handleSnapshot = (items) => {
+            syncAttendanceState(items);
+          };
+          const handleSubscriptionError = (error) => {
+            console.error('Attendance subscription error', error);
+            syncAttendanceState([]);
+            if (!isTeacher && !window.__attSubscriptionWarned) {
+              window.__attSubscriptionWarned = true;
+              alert('No se pudo consultar tu asistencia en línea por permisos insuficientes. Tu registro seguirá guardándose.');
             }
-            if (typeof window.updateAttendanceList === 'function') window.updateAttendanceList();
-            if (typeof window.updateAttendanceCount === 'function') window.updateAttendanceCount();
-          });
+          };
+          window.__attSubscriptionWarned = false;
+          try {
+            unsubscribeAttendance = isTeacher
+              ? subscribeTodayAttendance(handleSnapshot, handleSubscriptionError)
+              : subscribeTodayAttendanceByUser(normalizedEmail, handleSnapshot, handleSubscriptionError);
+          } catch (subscriptionError) {
+            handleSubscriptionError(subscriptionError);
+          }
         } else {
           userInfo.classList.add('hidden');
           if (signInBtn) signInBtn.classList.remove('hidden');
           setAttendanceEnabled(false);
+          applyRoleVisibility('estudiante');
           if (manualCard) {
             manualCard.classList.add('hidden');
             manualCard.style.display = 'none';
           }
           try { window.clearInterval(window.__classActiveTimer); } catch(_) {}
-          window.registeredAttendances = [];
-          if (typeof window.updateAttendanceList === 'function') window.updateAttendanceList();
-          if (typeof window.updateAttendanceCount === 'function') window.updateAttendanceCount();
+          syncAttendanceState([]);
           if (unsubscribeAttendance) { unsubscribeAttendance(); unsubscribeAttendance = null; }
+          window.__attSubscriptionWarned = false;
         }
       });
 
@@ -707,7 +754,11 @@
           if (manualEmailInput) manualEmailInput.value = '';
         } catch (error) {
           console.error('Manual attendance error', error);
-          alert(error?.message || 'No se pudo registrar manualmente.');
+          if (error?.code === 'permission-denied') {
+            alert('Tu cuenta no tiene permisos suficientes para registrar asistencias manuales. Verifica que hayas iniciado sesión como docente.');
+          } else {
+            alert(error?.message || 'No se pudo registrar manualmente.');
+          }
         } finally {
           manualBtn.disabled = false;
         }

--- a/asistencia.html
+++ b/asistencia.html
@@ -519,7 +519,7 @@
     </script>
 
     <script type="module">
-      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange, ensureTeacherDocForUser } from './js/firebase.js';
+      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange, ensureTeacherDocForUser, isTeacherEmail, isTeacherByDoc } from './js/firebase.js';
       import { allowedEmailDomain } from './js/firebase-config.js';
 
       initFirebase();
@@ -535,6 +535,8 @@
       const manualNameInput = document.getElementById('manualAttendanceName');
       const manualEmailInput = document.getElementById('manualAttendanceEmail');
       const manualBtn = document.getElementById('manualAttendanceBtn');
+
+      window.currentUserHasTeacherPrivileges = false;
 
       function setAttendanceEnabled(enabled) {
         if (!attendanceBtn) return;
@@ -617,27 +619,35 @@
           userInfo.classList.remove('hidden');
           if (signInBtn) signInBtn.classList.add('hidden');
 
-          const roster = Array.isArray(window.students) ? window.students : [];
-          const rosterEntry = roster.find((student) => (student.email || '').toLowerCase() === normalizedEmail);
-          const isTeacher = rosterEntry?.type === 'teacher';
+          let teacherByDoc = false;
+          try {
+            teacherByDoc = await isTeacherByDoc(user.uid);
+          } catch (err) {
+            console.error('No se pudo verificar el perfil de docente en Firestore', err);
+          }
 
-          if (isTeacher && user?.uid) {
+          const teacherByAllowlist = isTeacherEmail(normalizedEmail);
+          if (teacherByAllowlist && user?.uid && !teacherByDoc) {
             try {
-              await ensureTeacherDocForUser({
+              const ensured = await ensureTeacherDocForUser({
                 uid: user.uid,
                 email: normalizedEmail,
                 displayName: user.displayName,
               });
+              teacherByDoc = ensured || teacherByDoc;
             } catch (err) {
               console.error('No se pudo preparar el perfil de docente en Firestore', err);
             }
           }
 
-          applyRoleVisibility(isTeacher ? 'docente' : 'estudiante');
+          const hasTeacherPrivileges = teacherByDoc || teacherByAllowlist;
+          window.currentUserHasTeacherPrivileges = hasTeacherPrivileges;
+
+          applyRoleVisibility(hasTeacherPrivileges ? 'docente' : 'estudiante');
 
           if (manualCard) {
-            manualCard.classList.toggle('hidden', !isTeacher);
-            manualCard.style.display = isTeacher ? '' : 'none';
+            manualCard.classList.toggle('hidden', !hasTeacherPrivileges);
+            manualCard.style.display = hasTeacherPrivileges ? '' : 'none';
           }
 
           const active = (typeof window.isClassActiveNow === 'function' ? window.isClassActiveNow() : true);
@@ -661,14 +671,14 @@
           const handleSubscriptionError = (error) => {
             console.error('Attendance subscription error', error);
             syncAttendanceState([]);
-            if (!isTeacher && !window.__attSubscriptionWarned) {
+            if (!hasTeacherPrivileges && !window.__attSubscriptionWarned) {
               window.__attSubscriptionWarned = true;
               alert('No se pudo consultar tu asistencia en línea por permisos insuficientes. Tu registro seguirá guardándose.');
             }
           };
           window.__attSubscriptionWarned = false;
           try {
-            unsubscribeAttendance = isTeacher
+            unsubscribeAttendance = hasTeacherPrivileges
               ? subscribeTodayAttendance(handleSnapshot, handleSubscriptionError)
               : subscribeTodayAttendanceByUser(normalizedEmail, handleSnapshot, handleSubscriptionError);
           } catch (subscriptionError) {
@@ -683,6 +693,7 @@
             manualCard.classList.add('hidden');
             manualCard.style.display = 'none';
           }
+          window.currentUserHasTeacherPrivileges = false;
           try { window.clearInterval(window.__classActiveTimer); } catch(_) {}
           syncAttendanceState([]);
           if (unsubscribeAttendance) { unsubscribeAttendance(); unsubscribeAttendance = null; }
@@ -705,6 +716,10 @@
 
       async function manualRegisterAttendance() {
         if (!manualBtn) return;
+        if (!window.currentUserHasTeacherPrivileges) {
+          alert('Solo las cuentas de docente pueden registrar asistencias manuales.');
+          return;
+        }
         const roster = Array.isArray(window.students) ? window.students : [];
         const selectedId = manualSelect ? manualSelect.value : '';
         const typedEmail = (manualEmailInput?.value || '').trim().toLowerCase();

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -17,6 +17,7 @@ export const firebaseConfig = {
 export const allowedEmailDomain = "potros.itson.edu.mx";
 
 // Correos con permisos de docente (pueden editar calificaciones y materiales)
+// Mantener sincronizado con tools/firestore.rules > allowedTeacherEmails().
 export const allowedTeacherEmails = [
   "isaac.paniagua@potros.itson.edu.mx"
 ];

--- a/tools/firestore.rules
+++ b/tools/firestore.rules
@@ -60,9 +60,26 @@ service cloud.firestore {
     match /attendances/{attendanceId} {
       allow read: if isPotros();
       allow create: if isPotros()
-        && request.resource.data.email == request.auth.token.email
-        && request.resource.data.uid == request.auth.uid
-        && request.resource.data.date is string;
+        && request.resource.data.date is string
+        && request.resource.data.email is string
+        && request.resource.data.uid is string
+        && request.resource.data.manual is bool
+        && request.resource.data.createdByUid is string
+        && request.resource.data.createdByEmail is string
+        && (
+          (
+            request.resource.data.email == request.auth.token.email
+            && request.resource.data.uid == request.auth.uid
+            && request.resource.data.createdByUid == request.auth.uid
+            && request.resource.data.createdByEmail == request.auth.token.email
+          )
+          || (
+            isTeacher()
+            && request.resource.data.manual == true
+            && request.resource.data.createdByUid == request.auth.uid
+            && request.resource.data.createdByEmail == request.auth.token.email
+          )
+        );
       allow update, delete: if false;
     }
 

--- a/tools/firestore.rules
+++ b/tools/firestore.rules
@@ -7,9 +7,23 @@ service cloud.firestore {
     function isPotros() {
       return isSignedIn() && request.auth.token.email.matches('.*@potros\\.itson\\.edu\\.mx$');
     }
+    function allowedTeacherEmails() {
+      // Mantén esta lista sincronizada con allowedTeacherEmails en js/firebase-config.js
+      return [
+        'isaac.paniagua@potros.itson.edu.mx',
+      ];
+    }
+    function isAllowedTeacherEmail() {
+      return isPotros() && allowedTeacherEmails().hasAny([request.auth.token.email]);
+    }
     // Mark teachers by creating a doc at /teachers/{uid}
     function isTeacher() {
-      return isPotros() && exists(/databases/$(database)/documents/teachers/$(request.auth.uid));
+      return (
+        isPotros() && (
+          exists(/databases/$(database)/documents/teachers/$(request.auth.uid)) ||
+          isAllowedTeacherEmail()
+        )
+      );
     }
 
     // Mark teachers collection access
@@ -17,9 +31,9 @@ service cloud.firestore {
       // Allow get to let the client check its status
       allow get: if isPotros();
       // Allow the designated teacher to create their own marker doc
-      allow create: if isPotros()
-        && request.auth.token.email == 'isaac.paniagua@potros.itson.edu.mx'
-        && request.auth.uid == uid;
+      allow create: if isAllowedTeacherEmail()
+        && request.auth.uid == uid
+        && request.resource.data.email == request.auth.token.email;
       // Lock updates/deletes from client
       allow update, delete: if false;
     }


### PR DESCRIPTION
## Summary
- ensure asistencia.html registers the signed-in teacher in Firestore before exposing manual tools and clarifies permission errors
- relax attendance security rules so teachers can create manual entries while enforcing createdBy metadata

## Testing
- No automated tests were run (not available in repository).


------
https://chatgpt.com/codex/tasks/task_e_68cda6a0db988325b6d08339e1dcc0a4