### PR TITLE
Align manual attendance UI with Firebase teacher permissions

### DIFF
--- a/asistencia.html
+++ b/asistencia.html
@@ -119,7 +119,14 @@
               <input type="email" id="manualAttendanceEmail" class="form-input" placeholder="correo@potros.itson.edu.mx" />
             </div>
           </div>
+          <p id="manualAttendanceWarning" class="hidden mt-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3">
+            Tu cuenta aún no tiene permisos para registrar asistencias manuales en Firebase. Solicita que tu perfil docente sea habilitado para continuar.
+          </p>
           <button type="button" id="manualAttendanceBtn" class="submit-btn mt-6">Registrar asistencia manual</button>
+        </div>
+        <div class="teacher-only bg-white rounded-2xl shadow border border-amber-200 text-amber-700 px-6 py-5 mb-10 hidden" id="manualAttendanceNotice">
+          <h3 class="text-xl font-semibold mb-2">Permisos de registro manual pendientes</h3>
+          <p class="text-sm leading-relaxed">Iniciaste sesión con un perfil marcado como docente en la lista del curso, pero tu cuenta aún no tiene privilegios de docente en Firebase. Ponte en contacto con el administrador para habilitar tu acceso o utiliza el registro automático mientras tanto.</p>
         </div>
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
             <!-- Attendance Button Section -->
@@ -521,13 +528,6 @@
     <script type="module">
 
       import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange, ensureTeacherDocForUser, isTeacherEmail, isTeacherByDoc } from './js/firebase.js';
-
-
-      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange, ensureTeacherDocForUser, isTeacherEmail, isTeacherByDoc } from './js/firebase.js';
-
-      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange } from './js/firebase.js';
- main
- main
       import { allowedEmailDomain } from './js/firebase-config.js';
 
       initFirebase();
@@ -539,6 +539,8 @@
       const userPhoto = document.getElementById('userPhoto');
       const attendanceBtn = document.getElementById('attendanceBtn');
       const manualCard = document.getElementById('manualAttendanceCard');
+      const manualWarning = document.getElementById('manualAttendanceWarning');
+      const manualNotice = document.getElementById('manualAttendanceNotice');
       const manualSelect = document.getElementById('manualAttendanceSelect');
       const manualNameInput = document.getElementById('manualAttendanceName');
       const manualEmailInput = document.getElementById('manualAttendanceEmail');
@@ -628,7 +630,6 @@
           if (signInBtn) signInBtn.classList.add('hidden');
 
 
-main
           let teacherByDoc = false;
           try {
             teacherByDoc = await isTeacherByDoc(user.uid);
@@ -648,37 +649,30 @@ main
             } catch (err) {
               console.error('No se pudo preparar el perfil de docente en Firestore', err);
             }
+          }
 
           const roster = Array.isArray(window.students) ? window.students : [];
           const rosterEntry = roster.find((student) => (student.email || '').toLowerCase() === normalizedEmail);
-          const isTeacher = rosterEntry?.type === 'teacher';
+          const flaggedAsTeacher = rosterEntry?.type === 'teacher';
 
-          applyRoleVisibility(isTeacher ? 'docente' : 'estudiante');
+          const hasFirestoreTeacherPrivileges = teacherByDoc || teacherByAllowlist;
+          const showTeacherRoleUi = hasFirestoreTeacherPrivileges || flaggedAsTeacher;
+
+          window.currentUserHasTeacherPrivileges = hasFirestoreTeacherPrivileges;
+
+          applyRoleVisibility(showTeacherRoleUi ? 'docente' : 'estudiante');
 
           if (manualCard) {
-            manualCard.classList.toggle('hidden', !isTeacher);
-            manualCard.style.display = isTeacher ? '' : 'none';
- main
+            manualCard.classList.toggle('hidden', !hasFirestoreTeacherPrivileges);
+            manualCard.style.display = hasFirestoreTeacherPrivileges ? '' : 'none';
           }
-
-          const hasTeacherPrivileges = teacherByDoc || teacherByAllowlist;
-          window.currentUserHasTeacherPrivileges = hasTeacherPrivileges;
-
-          applyRoleVisibility(hasTeacherPrivileges ? 'docente' : 'estudiante');
-
-          if (manualCard) {
-            manualCard.classList.toggle('hidden', !hasTeacherPrivileges);
-            manualCard.style.display = hasTeacherPrivileges ? '' : 'none';
+          if (manualWarning) {
+            manualWarning.classList.add('hidden');
           }
-
-          const hasTeacherPrivileges = teacherByDoc || teacherByAllowlist;
-          window.currentUserHasTeacherPrivileges = hasTeacherPrivileges;
-
-          applyRoleVisibility(hasTeacherPrivileges ? 'docente' : 'estudiante');
-
-          if (manualCard) {
-            manualCard.classList.toggle('hidden', !hasTeacherPrivileges);
-            manualCard.style.display = hasTeacherPrivileges ? '' : 'none';
+          if (manualNotice) {
+            const showNotice = flaggedAsTeacher && !hasFirestoreTeacherPrivileges;
+            manualNotice.classList.toggle('hidden', !showNotice);
+            manualNotice.style.display = showNotice ? '' : 'none';
           }
 
           const active = (typeof window.isClassActiveNow === 'function' ? window.isClassActiveNow() : true);
@@ -695,39 +689,24 @@ main
             if (bannerNow) bannerNow.classList.toggle('hidden', !activeNow);
           }, 60000);
 
-          if (unsubscribeAttendance) unsubscribeAttendance();
-          const handleSnapshot = (items) => {
-            syncAttendanceState(items);
-          };
-          const handleSubscriptionError = (error) => {
-            console.error('Attendance subscription error', error);
-            syncAttendanceState([]);
+            if (unsubscribeAttendance) unsubscribeAttendance();
+            const handleSnapshot = (items) => {
+              syncAttendanceState(items);
+            };
+            const handleSubscriptionError = (error) => {
+              console.error('Attendance subscription error', error);
+              syncAttendanceState([]);
 
-            if (!hasTeacherPrivileges && !window.__attSubscriptionWarned) {
-
-
-            if (!hasTeacherPrivileges && !window.__attSubscriptionWarned) {
-
-            if (!isTeacher && !window.__attSubscriptionWarned) {
- main
- main
-              window.__attSubscriptionWarned = true;
-              alert('No se pudo consultar tu asistencia en línea por permisos insuficientes. Tu registro seguirá guardándose.');
-            }
-          };
-          window.__attSubscriptionWarned = false;
-          try {
-
-            unsubscribeAttendance = hasTeacherPrivileges
-
- 
-            unsubscribeAttendance = hasTeacherPrivileges
-
-            unsubscribeAttendance = isTeacher
- main
- main
-              ? subscribeTodayAttendance(handleSnapshot, handleSubscriptionError)
-              : subscribeTodayAttendanceByUser(normalizedEmail, handleSnapshot, handleSubscriptionError);
+              if (!hasTeacherPrivileges && !window.__attSubscriptionWarned) {
+                window.__attSubscriptionWarned = true;
+                alert('No se pudo consultar tu asistencia en línea por permisos insuficientes. Tu registro seguirá guardándose.');
+              }
+            };
+            window.__attSubscriptionWarned = false;
+            try {
+              unsubscribeAttendance = hasTeacherPrivileges
+                ? subscribeTodayAttendance(handleSnapshot, handleSubscriptionError)
+                : subscribeTodayAttendanceByUser(normalizedEmail, handleSnapshot, handleSubscriptionError);
           } catch (subscriptionError) {
             handleSubscriptionError(subscriptionError);
           }
@@ -739,6 +718,13 @@ main
           if (manualCard) {
             manualCard.classList.add('hidden');
             manualCard.style.display = 'none';
+          }
+          if (manualWarning) {
+            manualWarning.classList.add('hidden');
+          }
+          if (manualNotice) {
+            manualNotice.classList.add('hidden');
+            manualNotice.style.display = 'none';
           }
           window.currentUserHasTeacherPrivileges = false;
           try { window.clearInterval(window.__classActiveTimer); } catch(_) {}
@@ -797,6 +783,9 @@ main
 
         manualBtn.disabled = true;
         try {
+          if (manualWarning) {
+            manualWarning.classList.add('hidden');
+          }
           await saveTodayAttendance({
             uid,
             name,
@@ -814,10 +803,16 @@ main
           if (manualSelect) manualSelect.value = '';
           if (manualNameInput) manualNameInput.value = '';
           if (manualEmailInput) manualEmailInput.value = '';
+          if (manualWarning) {
+            manualWarning.classList.add('hidden');
+          }
         } catch (error) {
           console.error('Manual attendance error', error);
           if (error?.code === 'permission-denied') {
-            alert('Tu cuenta no tiene permisos suficientes para registrar asistencias manuales. Verifica que hayas iniciado sesión como docente.');
+            if (manualWarning) {
+              manualWarning.classList.remove('hidden');
+            }
+            alert('Tu cuenta aún no tiene privilegios habilitados en Firebase para registrar asistencias manuales. Solicita la activación de tu perfil docente.');
           } else {
             alert(error?.message || 'No se pudo registrar manualmente.');
           }


### PR DESCRIPTION
## Summary
- show dedicated notices when a rostered teacher lacks Firebase manual attendance privileges
- gate the manual attendance form and button on actual Firestore teacher access instead of roster role
- surface inline warnings whenever manual registration fails due to missing privileges

## Testing
- not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cdc912c6b8832597288b7c363e80e6