### PR TITLE
Restore manual attendance tests without Firebase privileges

### DIFF
--- a/asistencia.html
+++ b/asistencia.html
@@ -119,7 +119,14 @@
               <input type="email" id="manualAttendanceEmail" class="form-input" placeholder="correo@potros.itson.edu.mx" />
             </div>
           </div>
+          <p id="manualAttendanceWarning" class="hidden mt-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3">
+            Tu cuenta aún no tiene permisos para registrar asistencias manuales en Firebase. Solicita que tu perfil docente sea habilitado; mientras tanto, los registros se guardarán solo de forma local en esta sesión.
+          </p>
           <button type="button" id="manualAttendanceBtn" class="submit-btn mt-6">Registrar asistencia manual</button>
+        </div>
+        <div class="teacher-only bg-white rounded-2xl shadow border border-amber-200 text-amber-700 px-6 py-5 mb-10 hidden" id="manualAttendanceNotice">
+          <h3 class="text-xl font-semibold mb-2">Permisos de registro manual pendientes</h3>
+          <p class="text-sm leading-relaxed">Iniciaste sesión con un perfil marcado como docente en la lista del curso, pero tu cuenta aún no tiene privilegios de docente en Firebase. Ponte en contacto con el administrador para habilitar tu acceso o utiliza el registro automático mientras tanto.</p>
         </div>
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
             <!-- Attendance Button Section -->
@@ -521,13 +528,6 @@
     <script type="module">
 
       import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange, ensureTeacherDocForUser, isTeacherEmail, isTeacherByDoc } from './js/firebase.js';
-
-
-      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange, ensureTeacherDocForUser, isTeacherEmail, isTeacherByDoc } from './js/firebase.js';
-
-      import { initFirebase, onAuth, signInWithGooglePotros, signOutCurrent, saveTodayAttendance, subscribeTodayAttendance, subscribeTodayAttendanceByUser, fetchAttendancesByDateRange } from './js/firebase.js';
- main
- main
       import { allowedEmailDomain } from './js/firebase-config.js';
 
       initFirebase();
@@ -539,12 +539,15 @@
       const userPhoto = document.getElementById('userPhoto');
       const attendanceBtn = document.getElementById('attendanceBtn');
       const manualCard = document.getElementById('manualAttendanceCard');
+      const manualWarning = document.getElementById('manualAttendanceWarning');
+      const manualNotice = document.getElementById('manualAttendanceNotice');
       const manualSelect = document.getElementById('manualAttendanceSelect');
       const manualNameInput = document.getElementById('manualAttendanceName');
       const manualEmailInput = document.getElementById('manualAttendanceEmail');
       const manualBtn = document.getElementById('manualAttendanceBtn');
 
       window.currentUserHasTeacherPrivileges = false;
+      window.currentUserCanManualRegister = false;
 
       function setAttendanceEnabled(enabled) {
         if (!attendanceBtn) return;
@@ -628,7 +631,6 @@
           if (signInBtn) signInBtn.classList.add('hidden');
 
 
-main
           let teacherByDoc = false;
           try {
             teacherByDoc = await isTeacherByDoc(user.uid);
@@ -648,37 +650,32 @@ main
             } catch (err) {
               console.error('No se pudo preparar el perfil de docente en Firestore', err);
             }
+          }
 
           const roster = Array.isArray(window.students) ? window.students : [];
           const rosterEntry = roster.find((student) => (student.email || '').toLowerCase() === normalizedEmail);
-          const isTeacher = rosterEntry?.type === 'teacher';
+          const flaggedAsTeacher = rosterEntry?.type === 'teacher';
 
-          applyRoleVisibility(isTeacher ? 'docente' : 'estudiante');
+          const hasFirestoreTeacherPrivileges = teacherByDoc || teacherByAllowlist;
+          const showTeacherRoleUi = hasFirestoreTeacherPrivileges || flaggedAsTeacher;
+          const canUseManualUi = showTeacherRoleUi;
+
+          window.currentUserHasTeacherPrivileges = hasFirestoreTeacherPrivileges;
+          window.currentUserCanManualRegister = canUseManualUi;
+
+          applyRoleVisibility(showTeacherRoleUi ? 'docente' : 'estudiante');
 
           if (manualCard) {
-            manualCard.classList.toggle('hidden', !isTeacher);
-            manualCard.style.display = isTeacher ? '' : 'none';
- main
+            manualCard.classList.toggle('hidden', !canUseManualUi);
+            manualCard.style.display = canUseManualUi ? '' : 'none';
           }
-
-          const hasTeacherPrivileges = teacherByDoc || teacherByAllowlist;
-          window.currentUserHasTeacherPrivileges = hasTeacherPrivileges;
-
-          applyRoleVisibility(hasTeacherPrivileges ? 'docente' : 'estudiante');
-
-          if (manualCard) {
-            manualCard.classList.toggle('hidden', !hasTeacherPrivileges);
-            manualCard.style.display = hasTeacherPrivileges ? '' : 'none';
+          if (manualWarning) {
+            manualWarning.classList.add('hidden');
           }
-
-          const hasTeacherPrivileges = teacherByDoc || teacherByAllowlist;
-          window.currentUserHasTeacherPrivileges = hasTeacherPrivileges;
-
-          applyRoleVisibility(hasTeacherPrivileges ? 'docente' : 'estudiante');
-
-          if (manualCard) {
-            manualCard.classList.toggle('hidden', !hasTeacherPrivileges);
-            manualCard.style.display = hasTeacherPrivileges ? '' : 'none';
+          if (manualNotice) {
+            const showNotice = flaggedAsTeacher && !hasFirestoreTeacherPrivileges;
+            manualNotice.classList.toggle('hidden', !showNotice);
+            manualNotice.style.display = showNotice ? '' : 'none';
           }
 
           const active = (typeof window.isClassActiveNow === 'function' ? window.isClassActiveNow() : true);
@@ -695,39 +692,24 @@ main
             if (bannerNow) bannerNow.classList.toggle('hidden', !activeNow);
           }, 60000);
 
-          if (unsubscribeAttendance) unsubscribeAttendance();
-          const handleSnapshot = (items) => {
-            syncAttendanceState(items);
-          };
-          const handleSubscriptionError = (error) => {
-            console.error('Attendance subscription error', error);
-            syncAttendanceState([]);
+            if (unsubscribeAttendance) unsubscribeAttendance();
+            const handleSnapshot = (items) => {
+              syncAttendanceState(items);
+            };
+            const handleSubscriptionError = (error) => {
+              console.error('Attendance subscription error', error);
+              syncAttendanceState([]);
 
-            if (!hasTeacherPrivileges && !window.__attSubscriptionWarned) {
-
-
-            if (!hasTeacherPrivileges && !window.__attSubscriptionWarned) {
-
-            if (!isTeacher && !window.__attSubscriptionWarned) {
- main
- main
-              window.__attSubscriptionWarned = true;
-              alert('No se pudo consultar tu asistencia en línea por permisos insuficientes. Tu registro seguirá guardándose.');
-            }
-          };
-          window.__attSubscriptionWarned = false;
-          try {
-
-            unsubscribeAttendance = hasTeacherPrivileges
-
- 
-            unsubscribeAttendance = hasTeacherPrivileges
-
-            unsubscribeAttendance = isTeacher
- main
- main
-              ? subscribeTodayAttendance(handleSnapshot, handleSubscriptionError)
-              : subscribeTodayAttendanceByUser(normalizedEmail, handleSnapshot, handleSubscriptionError);
+              if (!hasFirestoreTeacherPrivileges && !window.__attSubscriptionWarned) {
+                window.__attSubscriptionWarned = true;
+                alert('No se pudo consultar tu asistencia en línea por permisos insuficientes. Tu registro seguirá guardándose.');
+              }
+            };
+            window.__attSubscriptionWarned = false;
+            try {
+              unsubscribeAttendance = hasFirestoreTeacherPrivileges
+                ? subscribeTodayAttendance(handleSnapshot, handleSubscriptionError)
+                : subscribeTodayAttendanceByUser(normalizedEmail, handleSnapshot, handleSubscriptionError);
           } catch (subscriptionError) {
             handleSubscriptionError(subscriptionError);
           }
@@ -740,7 +722,15 @@ main
             manualCard.classList.add('hidden');
             manualCard.style.display = 'none';
           }
+          if (manualWarning) {
+            manualWarning.classList.add('hidden');
+          }
+          if (manualNotice) {
+            manualNotice.classList.add('hidden');
+            manualNotice.style.display = 'none';
+          }
           window.currentUserHasTeacherPrivileges = false;
+          window.currentUserCanManualRegister = false;
           try { window.clearInterval(window.__classActiveTimer); } catch(_) {}
           syncAttendanceState([]);
           if (unsubscribeAttendance) { unsubscribeAttendance(); unsubscribeAttendance = null; }
@@ -763,8 +753,8 @@ main
 
       async function manualRegisterAttendance() {
         if (!manualBtn) return;
-        if (!window.currentUserHasTeacherPrivileges) {
-          alert('Solo las cuentas de docente pueden registrar asistencias manuales.');
+        if (!window.currentUserCanManualRegister) {
+          alert('Solo las cuentas autorizadas como docentes pueden registrar asistencias manuales.');
           return;
         }
         const roster = Array.isArray(window.students) ? window.students : [];
@@ -789,6 +779,7 @@ main
         const name = typedName || student?.name || email;
         const type = student?.type || 'manual';
         const uid = student?.uid || student?.id || `manual-${Date.now()}`;
+        const hasPrivileges = !!window.currentUserHasTeacherPrivileges;
 
         if (typeof window.isClassActiveNow === 'function' && !window.isClassActiveNow()) {
           const proceed = confirm('La clase no esta en horario. Registrar de todas formas?');
@@ -796,34 +787,71 @@ main
         }
 
         manualBtn.disabled = true;
+        const now = new Date();
+        let savedToFirestore = false;
         try {
-          await saveTodayAttendance({
-            uid,
-            name,
-            email,
-            type,
-            manual: true
-          });
-          const when = new Date();
-          if (typeof window.showSuccessModal === 'function') {
-            window.showSuccessModal({ name, type }, when);
+          if (manualWarning) {
+            manualWarning.classList.add('hidden');
           }
-          if (typeof window.showAttendanceToast === 'function') {
-            window.showAttendanceToast('Asistencia registrada manualmente');
+          if (hasPrivileges) {
+            await saveTodayAttendance({
+              uid,
+              name,
+              email,
+              type,
+              manual: true
+            });
+            savedToFirestore = true;
+          } else if (manualWarning) {
+            manualWarning.classList.remove('hidden');
           }
-          if (manualSelect) manualSelect.value = '';
-          if (manualNameInput) manualNameInput.value = '';
-          if (manualEmailInput) manualEmailInput.value = '';
         } catch (error) {
           console.error('Manual attendance error', error);
           if (error?.code === 'permission-denied') {
-            alert('Tu cuenta no tiene permisos suficientes para registrar asistencias manuales. Verifica que hayas iniciado sesión como docente.');
+            savedToFirestore = false;
+            if (manualWarning) {
+              manualWarning.classList.remove('hidden');
+            }
+            alert('Tu cuenta aún no tiene privilegios habilitados en Firebase para registrar asistencias manuales en Firebase. Se guardará solo de forma local en esta sesión.');
           } else {
             alert(error?.message || 'No se pudo registrar manualmente.');
+            return;
           }
         } finally {
           manualBtn.disabled = false;
         }
+
+        const record = {
+          uid,
+          id: uid,
+          name,
+          email,
+          type,
+          timestamp: now,
+          manual: true
+        };
+
+        if (!savedToFirestore) {
+          const current = Array.isArray(window.registeredAttendances)
+            ? window.registeredAttendances.slice()
+            : [];
+          current.unshift(record);
+          syncAttendanceState(current);
+        }
+
+        if (savedToFirestore && manualWarning) {
+          manualWarning.classList.add('hidden');
+        }
+
+        if (typeof window.showSuccessModal === 'function') {
+          window.showSuccessModal({ name, type }, now);
+        }
+        if (typeof window.showAttendanceToast === 'function') {
+          window.showAttendanceToast(savedToFirestore ? 'Asistencia registrada manualmente' : 'Asistencia guardada localmente');
+        }
+        if (manualSelect) manualSelect.value = '';
+        if (manualNameInput) manualNameInput.value = '';
+        if (manualEmailInput) manualEmailInput.value = '';
       }
       window.registerAttendance = async function registerAttendance() {
         if (typeof window.isClassActiveNow === 'function' && !window.isClassActiveNow()) {


### PR DESCRIPTION
## Summary
- show dedicated notices when a rostered teacher lacks Firebase manual attendance privileges and explain the local-only fallback
- keep the manual attendance UI available for rostered teachers while only attempting Firestore writes when privileges exist
- provide a local manual registration fallback and correct teacher privilege checks to avoid script errors

## Testing
- not run (HTML-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cdc912c6b8832597288b7c363e80e6