### PR TITLE
Add Iman Guaymas to student roster

### DIFF
--- a/asistencia.html
+++ b/asistencia.html
@@ -242,6 +242,7 @@
             {id: "244242", name: "Duarte Lopez, Adlemi Guadalupe", email: "adlemi.duarte244242@potros.itson.edu.mx", type: "student"},
             {id: "244473", name: "Espericueta Ramos, Jesus Alan", email: "jesus.espericueta244473@potros.itson.edu.mx", type: "student"},
             {id: "244608", name: "Gracia Morales, Sergio Alejandro", email: "sergio.gracia244608@potros.itson.edu.mx", type: "student"},
+            {id: "251001", name: "Guaymas, Iman", email: "iman.guaymas@potros.itson.edu.mx", type: "student"},
             {id: "228847", name: "Hernandez Gonzalez, Julian Ricardo", email: "julian.hernandez228847@potros.itson.edu.mx", type: "student"},
             {id: "248997", name: "Le Blohic Garay, Mario Enrique", email: "mario.leblohic248997@potros.itson.edu.mx", type: "student"},
             {id: "249012", name: "Lopez Guerrero, Luis Carlos", email: "luis.lopez249012@potros.itson.edu.mx", type: "student"},

--- a/calificaciones.html
+++ b/calificaciones.html
@@ -1192,6 +1192,11 @@
           email: "sergio.gracia244608@potros.itson.edu.mx",
         },
         {
+          id: "00000251001",
+          name: "Guaymas,Iman",
+          email: "iman.guaymas@potros.itson.edu.mx",
+        },
+        {
           id: "00000228847",
           name: "Hernandez Gonzalez,Julian Ricardo",
           email: "julian.hernandez228847@potros.itson.edu.mx",


### PR DESCRIPTION
## Summary
- add Iman Guaymas to the asistencia roster so her @potros account can authenticate for attendance
- include Iman Guaymas in the calificaciones dropdown to allow grade tracking setup

## Testing
- not run (static data update)


------
https://chatgpt.com/codex/tasks/task_e_68ce0870e7408325bcdfc80edc2b40cf