### PR TITLE
Prevent flashing wrong page during auth redirects

### DIFF
--- a/js/auth-guard.js
+++ b/js/auth-guard.js
@@ -13,9 +13,44 @@ const currentPage = (window.location.pathname.split('/').pop() || '').toLowerCas
 // Pages that should not trigger a redirect when no user is signed in.
 const skipPages = ['login.html', '404.html'];
 
+const AUTH_STORAGE_KEY = 'qs_auth_state';
+
+function readStoredAuthState() {
+  try {
+    const sessionValue = sessionStorage.getItem(AUTH_STORAGE_KEY);
+    if (sessionValue) return sessionValue;
+  } catch (_) {}
+  try {
+    const localValue = localStorage.getItem(AUTH_STORAGE_KEY);
+    if (localValue) return localValue;
+  } catch (_) {}
+  return '';
+}
+
+function persistAuthState(state) {
+  try {
+    sessionStorage.setItem(AUTH_STORAGE_KEY, state);
+  } catch (_) {}
+  try {
+    localStorage.setItem(AUTH_STORAGE_KEY, state);
+  } catch (_) {}
+  try {
+    window.__qsAuthState = state;
+  } catch (_) {}
+}
+
+// Expone en memoria el último estado conocido si estaba guardado previamente.
+// Esto evita que otras piezas lo reescriban con valores por defecto.
+try {
+  const stored = readStoredAuthState();
+  if (stored) window.__qsAuthState = stored;
+} catch (_) {}
+
 // Listen for authentication state changes. If there is no user and we are
 // currently on a protected page, redirect to the login page.
 onAuth((user) => {
+  const state = user ? 'signed-in' : 'signed-out';
+  persistAuthState(state);
   if (!user && !skipPages.includes(currentPage)) {
     // Preserve query parameters when redirecting to login by appending them
     const query = window.location.search || '';

--- a/js/nav-inject.js
+++ b/js/nav-inject.js
@@ -53,17 +53,16 @@ function initNavInject(){
       /* Override any previous pseudo icon */
       .qs-brand::before { content: none !important; }
       body { padding-top: calc(var(--nav-h, 64px) + 8px); }
-      .qs-nav { position: fixed; top:0; left:0; right:0; z-index:1000; backdrop-filter:saturate(140%) blur(18px); background:rgba(255,255,255,0.95); border-bottom:1px solid rgba(255,255,255,0.2); box-shadow:0 8px 32px rgba(0,0,0,0.10); }
+      .qs-nav { position: fixed; top:0; left:0; right:0; z-index:1000; background:#ffffff; border-bottom:1px solid #e5e7eb; }
       .qs-nav .wrap { max-width:1200px; margin:0 auto; padding:14px 20px; display:flex; gap:16px; align-items:center; justify-content:space-between; }
-      .qs-brand { display:flex; gap:12px; align-items:center; color:#1f2937; font-weight:800; font-size:1.2rem; text-decoration:none; padding:6px 12px; border-radius:16px; }
-      .qs-brand:hover { transform: translateY(-2px) scale(1.02); transition: transform .25s ease; }
-      .qs-logo { width:28px; height:28px; border-radius:8px; background:linear-gradient(135deg,#667eea,#764ba2); color:#fff; display:inline-flex; align-items:center; justify-content:center; font-weight:800; font-size:.9rem; letter-spacing:.5px; box-shadow:0 6px 16px rgba(102,126,234,.35); transition: transform .25s ease; }
-      .qs-brand:hover .qs-logo { transform: rotate(8deg) scale(1.05); }
-      .qs-title { background:linear-gradient(135deg,#4f46e5,#7c3aed); -webkit-background-clip:text; background-clip:text; color:transparent; font-weight:800; }
-      .qs-tabs { display:flex; gap:10px; flex-wrap:nowrap; overflow-x:auto; white-space:nowrap; background:rgba(255,255,255,0.3); padding:6px; border-radius:30px; backdrop-filter:blur(10px); }
-      .qs-btn { border:0; padding:10px 16px; border-radius:22px; background:rgba(255,255,255,0.7); color:#374151; text-decoration:none; font-weight:600; font-size:.9rem; transition:all .25s ease; border:2px solid transparent; flex:0 0 auto; }
-      .qs-btn:hover { color:#fff; transform:translateY(-2px); box-shadow:0 8px 18px rgba(102,126,234,.35); border-color:rgba(102,126,234,.25); background:linear-gradient(135deg,#667eea,#764ba2); }
-      .qs-btn[aria-current="page"] { background:linear-gradient(135deg,#667eea,#764ba2); color:#fff; box-shadow:0 6px 16px rgba(102,126,234,.45); }
+      .qs-brand { display:flex; gap:10px; align-items:center; color:#1f2937; font-weight:700; font-size:1.1rem; text-decoration:none; padding:6px 0; }
+      .qs-brand:hover { color:#1d4ed8; }
+      .qs-logo { width:28px; height:28px; border-radius:6px; background:#4f46e5; color:#fff; display:inline-flex; align-items:center; justify-content:center; font-weight:700; font-size:.9rem; letter-spacing:.5px; }
+      .qs-title { color:inherit; font-weight:700; }
+      .qs-tabs { display:flex; gap:8px; flex-wrap:nowrap; overflow-x:auto; white-space:nowrap; background:none; padding:4px; border-radius:999px; }
+      .qs-btn { border:0; padding:8px 14px; border-radius:999px; background:transparent; color:#374151; text-decoration:none; font-weight:600; font-size:.9rem; flex:0 0 auto; }
+      .qs-btn:hover { background:#e0e7ff; color:#1d4ed8; }
+      .qs-btn[aria-current="page"] { background:#4338ca; color:#fff; }
     `;
 
     var style = document.getElementById('qs-nav-inline-style');
@@ -103,6 +102,67 @@ function initNavInject(){
         nav.innerHTML = template;
       }
     }
+
+    function getStoredAuthState(){
+      var key = 'qs_auth_state';
+      try {
+        var sessionValue = sessionStorage.getItem(key);
+        if (sessionValue) return sessionValue;
+      } catch (_) {}
+      try {
+        var localValue = localStorage.getItem(key);
+        if (localValue) return localValue;
+      } catch (_) {}
+      if (typeof window !== 'undefined' && window.__qsAuthState) {
+        return window.__qsAuthState;
+      }
+      return '';
+    }
+
+    function shouldBypassAuth(href){
+      if (!href) return true;
+      var trimmed = href.trim();
+      if (!trimmed) return true;
+      var lower = trimmed.split('#')[0].split('?')[0].toLowerCase();
+      if (!lower) return true;
+      if (lower === 'login.html' || lower === '404.html') return true;
+      var lowerTrimmed = trimmed.toLowerCase();
+      if (lowerTrimmed.indexOf('mailto:') === 0 || lowerTrimmed.indexOf('tel:') === 0) return true;
+      if (lowerTrimmed.indexOf('javascript:') === 0) return true;
+      if (/^https?:\/\//i.test(trimmed)) return true;
+      if (trimmed.charAt(0) === '#') return true;
+      return false;
+    }
+
+    function bindNavAuthRedirect(navEl){
+      if (!navEl || navEl.__qsAuthRedirectBound) return;
+      navEl.__qsAuthRedirectBound = true;
+      navEl.addEventListener('click', function(evt){
+        try {
+          var anchor = evt.target && evt.target.closest ? evt.target.closest('a[href]') : null;
+          if (!anchor) return;
+          if (!navEl.contains(anchor)) return;
+          var href = anchor.getAttribute('href') || '';
+          if (shouldBypassAuth(href)) return;
+          var state = getStoredAuthState();
+          if (state && state !== 'signed-in' && state !== 'unknown') {
+            evt.preventDefault();
+            var loginUrl = prefix + 'login.html';
+            try {
+              if (window.location.replace) {
+                window.location.replace(loginUrl);
+              } else {
+                window.location.href = loginUrl;
+              }
+            } catch (_) {
+              window.location.href = loginUrl;
+            }
+          }
+        } catch (_) {}
+      }, true);
+    }
+
+    bindNavAuthRedirect(nav);
 
     // Mark active link
     var current = (location.pathname.split('/').pop()||'').toLowerCase();


### PR DESCRIPTION
## Summary
- store the last known Firebase auth state in storage so navigation can read it early
- intercept navigation clicks in the injected nav to route signed-out users straight to login
- simplify the injected navigation styles so only a basic hover color change runs during load

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce30cf119c83259e1800e622496959