### PR TITLE
Unificar footer en todas las vistas

### DIFF
--- a/asistencia.html
+++ b/asistencia.html
@@ -838,7 +838,7 @@
   document.getElementById('exportAttendanceRangePdfBtn')?.addEventListener('click', ()=>exportRange(true));
 </script>
 
-<footer class="footer">
+<footer class="footer" data-footer-version="2024-unified">
   <div class="footer-content">© 2024 · Plataforma QS - Calidad de Software | Isaac Paniagua</div>
 </footer>
 <script>

--- a/index.html
+++ b/index.html
@@ -374,10 +374,8 @@
     </main>
 
     <!-- Pie de página -->
-    <footer class="footer">
-      <div class="footer-content">
-        2024 Plataforma QS - Calidad de Software | Isaac Paniagua
-      </div>
+    <footer class="footer" data-footer-version="2024-unified">
+      <div class="footer-content">© 2024 · Plataforma QS - Calidad de Software | Isaac Paniagua</div>
     </footer>
 
     <script>

--- a/js/layout.js
+++ b/js/layout.js
@@ -204,7 +204,7 @@ function initLayout() {
 
     // Footer compartido
     const year = new Date().getFullYear();
-    const footerHtml = `<div class="footer-content">© ${year} Plataforma QS - Calidad de Software | Isaac Paniagua</div>`;
+    const footerHtml = `<div class="footer-content">© ${year} · Plataforma QS - Calidad de Software | Isaac Paniagua</div>`;
     let footer = document.querySelector("footer.footer");
     if (!footer) {
       footer = document.createElement("footer");
@@ -212,6 +212,7 @@ function initLayout() {
       document.body.appendChild(footer);
     }
     footer.innerHTML = footerHtml;
+    footer.setAttribute("data-footer-version", "2024-unified");
 
     // Carga de guardia de autenticación para páginas con navegación global.
     // Inserta un script de tipo módulo que importa Firebase y redirige a login.html

--- a/js/nav-inject.js
+++ b/js/nav-inject.js
@@ -145,6 +145,29 @@ html:not(.role-teacher) .teacher-only{display:none !important;}
       }
     }
 
+    function ensureUnifiedFooter(){
+      try {
+        var year = new Date().getFullYear();
+        var version = '2024-unified';
+        var footerMarkup = '<div class="footer-content">© ' +
+          year + ' · Plataforma QS - Calidad de Software | Isaac Paniagua</div>';
+        var footer = document.querySelector('footer.footer');
+        if (!footer) {
+          footer = document.createElement('footer');
+          footer.className = 'footer';
+          document.body.appendChild(footer);
+        } else {
+          footer.classList.add('footer');
+        }
+        if ((footer.innerHTML || '').trim() !== footerMarkup) {
+          footer.innerHTML = footerMarkup;
+        }
+        footer.setAttribute('data-footer-version', version);
+      } catch (_) {}
+    }
+
+    ensureUnifiedFooter();
+
 
     function ensureNavToggle(navEl){
       if (!navEl || navEl.__qsToggleBound) return;

--- a/sesio12.html
+++ b/sesio12.html
@@ -6,7 +6,7 @@
     <title>Sesión 12: Planes de Calidad (SQA Plan)</title>
     
 <!-- Pie de página -->
-<footer class="footer">
+<footer class="footer" data-footer-version="2024-unified">
   <div class="footer-content">© 2024 · Plataforma QS - Calidad de Software | Isaac Paniagua</div>
 </footer>
 


### PR DESCRIPTION
## Summary
- unificar el pie de página inyectado para que todas las vistas compartan el mismo texto y versión
- actualizar la plantilla de footer global en layout.js para usar el mismo formato
- alinear los footers presentes en HTML estáticos con el nuevo formato unificado

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cee68a18fc8325bad6020cdb1a7666