### PR TITLE
Remove navbar authentication button

### DIFF
--- a/Foro.html
+++ b/Foro.html
@@ -51,11 +51,6 @@
             <a class="qs-btn" href="Foro.html">Foro</a>
             <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="login.html" data-default-auth-link
-              >Iniciar sesión</a
-            >
-          </div>
         </div>
       </div>
     </div>

--- a/asistencia.html
+++ b/asistencia.html
@@ -79,15 +79,11 @@
             <a class="qs-btn" href="Foro.html">Foro</a>
             <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="login.html" data-default-auth-link
-              >Iniciar sesión</a
-            >
-          </div>
         </div>
       </div>
     </div>
-<div class="container mx-auto px-4 py-8 max-w-6xl">
+
+    <div class="container mx-auto px-4 py-8 max-w-6xl">
         <!-- Header -->
         <div class="bg-white rounded-2xl shadow-xl p-8 mb-8 border border-gray-100">
             <div class="text-center">

--- a/calificaciones.html
+++ b/calificaciones.html
@@ -148,11 +148,6 @@
             <a class="qs-btn" href="Foro.html">Foro</a>
             <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="login.html" data-default-auth-link
-              >Iniciar sesión</a
-            >
-          </div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -517,11 +517,6 @@
             <a class="qs-btn" href="Foro.html">Foro</a>
             <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="login.html" data-default-auth-link
-              >Iniciar sesión</a
-            >
-          </div>
         </div>
       </div>
     </div>

--- a/js/layout.js
+++ b/js/layout.js
@@ -110,9 +110,6 @@ function bootstrapLayout() {
             <a class="qs-btn" href="${base}Foro.html">Foro</a>
             <a class="qs-btn teacher-only" data-route="panel" href="${base}paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="${base}login.html" data-default-auth-link>Iniciar sesión</a>
-          </div>
         </div>
       </div>`;
 
@@ -130,8 +127,6 @@ function bootstrapLayout() {
       if (nav.getAttribute("data-nav-version") !== NAV_VERSION) {
         nav.innerHTML = template;
         nav.setAttribute("data-nav-version", NAV_VERSION);
-      } else {
-        ensureAuthSlot(nav);
       }
     }
 

--- a/materiales.html
+++ b/materiales.html
@@ -253,11 +253,6 @@
             <a class="qs-btn" href="Foro.html">Foro</a>
             <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="login.html" data-default-auth-link
-              >Iniciar sesión</a
-            >
-          </div>
         </div>
       </div>
     </div>

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -303,11 +303,6 @@
             <a class="qs-btn" href="Foro.html">Foro</a>
             <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="login.html" data-default-auth-link
-              >Iniciar sesión</a
-            >
-          </div>
         </div>
       </div>
     </div>

--- a/sesion1.html
+++ b/sesion1.html
@@ -367,11 +367,6 @@
             <a class="qs-btn" href="Foro.html">Foro</a>
             <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="login.html" data-default-auth-link
-              >Iniciar sesión</a
-            >
-          </div>
         </div>
       </div>
     </div>

--- a/sesion45.html
+++ b/sesion45.html
@@ -129,11 +129,6 @@
             <a class="qs-btn" href="Foro.html">Foro</a>
             <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
           </nav>
-          <div class="qs-actions" data-auth-slot>
-            <a class="qs-cta" href="login.html" data-default-auth-link
-              >Iniciar sesión</a
-            >
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the login/logout call-to-action from the navigation markup on every page
- update the shared layout script so regenerated navbars also omit the authentication slot

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cef334bb9483259f0979d6bb698375