### PR TITLE
Oculta panel docente para estudiantes

### DIFF
--- a/Foro.html
+++ b/Foro.html
@@ -49,7 +49,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/asistencia.html
+++ b/asistencia.html
@@ -77,7 +77,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/calificaciones.html
+++ b/calificaciones.html
@@ -146,7 +146,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -515,7 +515,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/js/layout.js
+++ b/js/layout.js
@@ -39,6 +39,9 @@ function bootstrapLayout() {
   const nav = ensureNavigation(basePath);
   const footer = ensureFooter();
 
+  toggleTeacherNavLinks(html.classList.contains("role-teacher"));
+  observeRoleClassChanges();
+
   updateAuthAppearance(nav, readStoredAuthState());
   bindNavAuthRedirect(nav);
   setupNavToggle(nav);
@@ -60,6 +63,7 @@ function bootstrapLayout() {
   window.__qsLayoutReadAuthState = readStoredAuthState;
   window.__qsLayoutPersistAuthState = persistAuthState;
   window.__qsLayoutPersistRole = persistRole;
+  window.__qsLayoutToggleTeacherNavLinks = toggleTeacherNavLinks;
 
   function computeBasePath() {
     try {
@@ -108,7 +112,13 @@ function bootstrapLayout() {
             <a class="qs-btn" href="${base}asistencia.html">Asistencia</a>
             <a class="qs-btn" href="${base}calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="${base}Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" data-route="panel" href="${base}paneldocente.html">Panel</a>
+            <a
+              class="qs-btn teacher-only"
+              data-route="panel"
+              href="${base}paneldocente.html"
+              hidden
+              aria-hidden="true"
+            >Panel</a>
           </nav>
         </div>
       </div>`;
@@ -221,6 +231,7 @@ function bootstrapLayout() {
     try {
       localStorage.setItem(ROLE_STORAGE_KEY, role);
     } catch (_) {}
+    toggleTeacherNavLinks(role === "docente");
   }
 
   function updateAuthAppearance(nav, state) {
@@ -241,6 +252,35 @@ function bootstrapLayout() {
         defaultLink.title = "Iniciar sesión";
         defaultLink.setAttribute("data-awaiting-auth", "signed-out");
       }
+    } catch (_) {}
+  }
+
+  function toggleTeacherNavLinks(isTeacher) {
+    try {
+      const links = nav ? nav.querySelectorAll("[data-route='panel']") : [];
+      links.forEach((link) => {
+        if (!link) return;
+        if (isTeacher) {
+          link.removeAttribute("hidden");
+          link.removeAttribute("aria-hidden");
+        } else {
+          link.setAttribute("hidden", "hidden");
+          link.setAttribute("aria-hidden", "true");
+        }
+      });
+    } catch (_) {}
+  }
+
+  function observeRoleClassChanges() {
+    if (!html || !window.MutationObserver) return;
+    try {
+      const observer = new MutationObserver(() => {
+        toggleTeacherNavLinks(html.classList.contains("role-teacher"));
+      });
+      observer.observe(html, {
+        attributes: true,
+        attributeFilter: ["class"],
+      });
     } catch (_) {}
   }
 

--- a/materiales.html
+++ b/materiales.html
@@ -262,7 +262,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -301,7 +301,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/sesion1.html
+++ b/sesion1.html
@@ -365,7 +365,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/sesion45.html
+++ b/sesion45.html
@@ -127,7 +127,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- oculta el enlace al panel docente para estudiantes desde el layout central y reacciona a cambios del rol
- marca el enlace del panel como oculto por defecto en las vistas con navegación estática para evitar parpadeos

## Testing
- no se ejecutaron pruebas (sitio estático)


------
https://chatgpt.com/codex/tasks/task_e_68cefe3f534c832597a33b0dfea3f78a