### PR TITLE
Agrega overlay de carga al iniciar layout

### DIFF
--- a/Foro.html
+++ b/Foro.html
@@ -49,7 +49,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/asistencia.html
+++ b/asistencia.html
@@ -77,7 +77,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/calificaciones.html
+++ b/calificaciones.html
@@ -146,7 +146,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/css/layout.css
+++ b/css/layout.css
@@ -75,6 +75,70 @@ body {
     linear-gradient(165deg, #f8fafc 0%, #eef2ff 55%, #fdf2f8 100%);
 }
 
+html.qs-loading body {
+  overflow: hidden;
+}
+
+.qs-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 4000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 8vw, 64px);
+  background:
+    radial-gradient(circle at 22% 18%, rgba(129, 140, 248, 0.28), transparent 58%),
+    radial-gradient(circle at 82% 12%, rgba(14, 165, 233, 0.3), transparent 60%),
+    rgba(15, 23, 42, 0.94);
+  color: rgba(226, 232, 240, 0.94);
+  transition:
+    opacity var(--motion-duration-slow) var(--motion-easing),
+    visibility var(--motion-duration-slow) var(--motion-easing);
+}
+
+.qs-loading-overlay.is-hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.qs-loading-card {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(16px, 4vw, 24px);
+  padding: clamp(18px, 4vw, 32px);
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.45);
+  text-align: center;
+}
+
+.qs-loading-spinner {
+  width: clamp(42px, 8vw, 56px);
+  height: clamp(42px, 8vw, 56px);
+  border-radius: 999px;
+  border: 4px solid rgba(148, 163, 184, 0.35);
+  border-top-color: #38bdf8;
+  animation: qs-loading-spin 1s linear infinite;
+}
+
+.qs-loading-text {
+  margin: 0;
+  font-size: clamp(1rem, 2.8vw, 1.25rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
+@keyframes qs-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .transition-all {
   transition-property: all;
   transition-duration: var(--motion-duration);

--- a/index.html
+++ b/index.html
@@ -515,7 +515,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/materiales.html
+++ b/materiales.html
@@ -262,7 +262,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -301,7 +301,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/sesion1.html
+++ b/sesion1.html
@@ -365,7 +365,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>

--- a/sesion45.html
+++ b/sesion45.html
@@ -127,7 +127,7 @@
             <a class="qs-btn" href="asistencia.html">Asistencia</a>
             <a class="qs-btn" href="calificaciones.html">Calificaciones</a>
             <a class="qs-btn" href="Foro.html">Foro</a>
-            <a class="qs-btn teacher-only" href="paneldocente.html">Panel</a>
+            <a class="qs-btn teacher-only" href="paneldocente.html" hidden aria-hidden="true">Panel</a>
           </nav>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- agrega un overlay de carga accesible mientras el layout global termina de inicializarse
- marca el html como cargado al finalizar el bootstrap y elimina la animación tras una transición suave
- incorpora estilos y animaciones para el indicador de carga y bloquea el scroll durante la espera

## Testing
- no se ejecutaron pruebas (sitio estático)


------
https://chatgpt.com/codex/tasks/task_e_68cefe3f534c832597a33b0dfea3f78a