### PR TITLE
Remove role toggle from materiales header

### DIFF
--- a/materiales.html
+++ b/materiales.html
@@ -270,14 +270,6 @@
 
     <div class="main-container">
       <div class="header">
-        <div class="role-toggle">
-          <button type="button" class="role-btn" id="teacherBtn">
-            👩‍🏫 Profesor
-          </button>
-          <button type="button" class="role-btn active" id="studentBtn">
-            🧑‍🎓 Estudiante
-          </button>
-        </div>
         <div class="header-content">
           <h1 class="platform-title">📚 Materiales de Curso</h1>
           <p class="platform-subtitle">


### PR DESCRIPTION
## Summary
- remove the role toggle button group from the Materials page header

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68cf0813e56c8325a2d98ccc10dd80a6