### PR TITLE
Handle materiales DOM guards, simplify nav loader resolution, and align panel nav style

### DIFF
--- a/js/nav-inject.js
+++ b/js/nav-inject.js
@@ -11,18 +11,15 @@
     if (configuredSrc) {
       layoutSrc = configuredSrc;
     } else if (currentScript.src) {
-      try {
-        const scriptUrl = new URL(currentScript.src, window.location.href);
-        const basePath = scriptUrl.pathname.substring(
-          0,
-          scriptUrl.pathname.lastIndexOf("/") + 1
-        );
-        const resolvedUrl = new URL("layout.js", `${scriptUrl.origin}${basePath}`);
-        layoutSrc = resolvedUrl.href;
-      } catch (error) {
+      const anchor = document.createElement("a");
+      anchor.href = currentScript.src;
+
+      if (anchor.protocol && anchor.host) {
+        const basePath = anchor.pathname.replace(/[^/]*$/, "");
+        layoutSrc = `${anchor.protocol}//${anchor.host}${basePath}layout.js`;
+      } else {
         console.warn(
-          "nav-inject.js: no se pudo resolver la ruta hacia layout.js; se usará la predeterminada.",
-          error
+          "nav-inject.js: no se pudo resolver la ruta hacia layout.js; se usará la predeterminada."
         );
       }
     }

--- a/materiales.html
+++ b/materiales.html
@@ -369,6 +369,25 @@
         emptyMessage: document.getElementById("emptyMessage"),
       };
 
+      const essentialElementKeys = [
+        "grid",
+        "emptyState",
+        "emptyMessage",
+        "notification",
+        "notificationMessage",
+      ];
+
+      const missingEssentialElements = essentialElementKeys.filter(
+        (key) => !elements[key]
+      );
+
+      if (missingEssentialElements.length > 0) {
+        console.error(
+          "materiales.html: faltan elementos esenciales en el DOM",
+          missingEssentialElements
+        );
+      }
+
       onAuth(async (user) => {
         if (user) {
           currentUser = user;
@@ -380,13 +399,18 @@
       });
 
       async function initializeApp() {
+        if (missingEssentialElements.length > 0) {
+          return;
+        }
         // Inicializa el widget DESPUÉS de que sabemos que el usuario es un profesor
         if (isCurrentUserTeacher && elements.form) {
           uploadcareWidget = uploadcare.Widget("#file-widget");
           elements.form.addEventListener("submit", handleFormSubmit);
         }
 
-        elements.grid.addEventListener("click", handleGridClick);
+        if (elements.grid) {
+          elements.grid.addEventListener("click", handleGridClick);
+        }
 
         try {
           allMaterials = await getMaterials();
@@ -394,14 +418,19 @@
         } catch (error) {
           console.error("Error al inicializar:", error);
           showNotification("error", "No se pudieron cargar los materiales.");
-          elements.emptyMessage.textContent =
-            "Error al cargar. Revisa los permisos.";
+          if (elements.emptyMessage) {
+            elements.emptyMessage.textContent =
+              "Error al cargar. Revisa los permisos.";
+          }
         }
 
         applyRoleVisibility();
       }
 
       function render() {
+        if (!elements.grid || !elements.emptyState || !elements.emptyMessage) {
+          return;
+        }
         elements.grid.innerHTML = "";
         if (allMaterials.length === 0) {
           elements.emptyState.classList.remove("hidden");
@@ -570,6 +599,10 @@
         return p.innerHTML;
       }
       function showNotification(type, message) {
+        if (!elements.notification || !elements.notificationMessage) {
+          console.warn("materiales.html: no se encontró el contenedor de notificaciones.");
+          return;
+        }
         elements.notificationMessage.textContent = message;
         elements.notification.className = `notification ${
           type === "error" ? "error" : ""

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" data-layout="global">
   <head>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="./css/layout.css" />
+    <script src="js/student-nav-fixed.js"></script>
 
     <script>
       window.firebaseConfig = {
@@ -291,7 +292,7 @@
             <span class="sr-only">Abrir menú</span>
           </button>
         </div>
-        <div class="qs-links-region">
+        <div class="qs-links-region" data-open="false">
           <nav
             class="qs-tabs"
             id="qs-nav-links"


### PR DESCRIPTION
## Summary
- resolve the layout loader URL in `nav-inject.js` with a safe anchor-based fallback to avoid syntax errors while parsing the script
- add guards in `materiales.html` so initialization is skipped when essential DOM nodes are missing and avoid null dereference errors
- align the `paneldocente.html` navigation with the shared layout styling by enabling the global layout mode and loading the critical nav script

## Testing
- node _check.js *(fails: SyntaxError: Unexpected end of input)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0c3c60a08325af300792bbe1ebc1