### PR TITLE
Corrige el límite máximo en la captura de calificaciones

### DIFF
--- a/calificaciones.html
+++ b/calificaciones.html
@@ -462,7 +462,21 @@
 
         <!-- Botón para mostrar la vista de alumno: cuando se pulsa, desplaza la página hacia la vista de estudiante (student-preview). -->
 
-        <div class="mt-4">
+        <div class="mt-4 flex flex-wrap items-center gap-3">
+
+          <button
+
+            id="saveGradesBtn"
+
+            class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+
+            type="button"
+
+          >
+
+            Guardar cambios
+
+          </button>
 
           <button
 
@@ -477,6 +491,16 @@
             Vista de alumno
 
           </button>
+
+          <p
+
+            id="saveGradesStatus"
+
+            class="text-sm text-emerald-600 hidden"
+
+            aria-live="polite"
+
+          ></p>
 
         </div>
 
@@ -732,7 +756,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -778,7 +802,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -824,7 +848,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -870,7 +894,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -912,7 +936,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -956,7 +980,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1000,7 +1024,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1064,7 +1088,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1110,7 +1134,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1156,7 +1180,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1198,7 +1222,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1242,7 +1266,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1302,7 +1326,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1344,7 +1368,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1386,7 +1410,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1428,7 +1452,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1470,7 +1494,7 @@
 
                 min="0"
 
-                max="5"
+                max="10"
 
                 step="0.1"
 
@@ -1546,7 +1570,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1588,7 +1612,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1630,7 +1654,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1694,7 +1718,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1736,7 +1760,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1778,7 +1802,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1842,7 +1866,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1884,7 +1908,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1926,7 +1950,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -1968,7 +1992,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -2032,7 +2056,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -2074,7 +2098,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -2116,7 +2140,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -2158,7 +2182,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -2200,7 +2224,7 @@
 
                   min="0"
 
-                  max="5"
+                  max="10"
 
                   step="0.1"
 
@@ -3197,6 +3221,72 @@
         });
 
       });
+
+
+
+      // Manual save button for docentes
+
+      (function setupSaveButton() {
+
+        const saveButton = document.getElementById("saveGradesBtn");
+
+        const statusEl = document.getElementById("saveGradesStatus");
+
+        if (!saveButton) return;
+
+        let hideTimer = null;
+
+        function showStatus(message, isError) {
+
+          if (!statusEl) return;
+
+          statusEl.textContent = message;
+
+          statusEl.classList.remove("hidden");
+
+          statusEl.classList.toggle("text-red-600", !!isError);
+
+          statusEl.classList.toggle("text-emerald-600", !isError);
+
+          if (hideTimer) {
+
+            clearTimeout(hideTimer);
+
+            hideTimer = null;
+
+          }
+
+          hideTimer = setTimeout(() => {
+
+            statusEl.classList.add("hidden");
+
+            hideTimer = null;
+
+          }, 4000);
+
+        }
+
+        saveButton.addEventListener("click", () => {
+
+          const studentInput = document.getElementById("studentId");
+
+          const studentId = studentInput ? studentInput.value : "";
+
+          if (!studentId) {
+
+            showStatus("Selecciona un estudiante antes de guardar.", true);
+
+            return;
+
+          }
+
+          saveStudentGrades(studentId);
+
+          showStatus("Calificaciones guardadas correctamente.", false);
+
+        });
+
+      })();
 
 
 

--- a/js/calificaciones-teacher-sync.js
+++ b/js/calificaciones-teacher-sync.js
@@ -360,7 +360,7 @@ if (localClear) {
   };
 }
 
-const flushButtons = ['calculateBtn', 'exportBtn'];
+const flushButtons = ['calculateBtn', 'exportBtn', 'saveGradesBtn'];
 flushButtons.forEach((id) => {
   const btn = document.getElementById(id);
   if (!btn) return;


### PR DESCRIPTION
## Summary
- actualicé todos los campos de captura de calificaciones para que el valor máximo permitido sea 10 desde el marcado inicial
- evito que la sincronización con Firestore recorte calificaciones superiores a 5 en actividades y rúbricas
- añadí un botón de "Guardar cambios" exclusivo para docentes que dispara el guardado local y remoto de calificaciones

## Testing
- no se ejecutaron pruebas automatizadas (cambios en HTML estático y lógica de UI)


------
https://chatgpt.com/codex/tasks/task_e_68d019fd23208325a01ffd5104c402c2