### PR TITLE
Adjust hero card spacing from navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,7 @@
         display: grid;
         grid-template-columns: minmax(0, 1.1fr) minmax(280px, 1fr);
         gap: clamp(28px, 5vw, 52px);
+        margin-top: clamp(24px, 6vw, 72px);
         padding: clamp(36px, 6vw, 68px);
         border-radius: var(--radius-xl);
         background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(238, 242, 255, 0.95));


### PR DESCRIPTION
## Summary
- add a responsive top margin to the hero card so it sits farther from the navbar

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d07141586883258ad3bfebb629d89a