### PR TITLE
Ajusta espacio entre navegación y contenido principal

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -69,7 +69,7 @@ body {
   font-family: var(--font-sans);
   line-height: 1.6;
   color: #0f172a;
-  padding-top: calc(var(--nav-h, 60px) + 24px);
+  padding-top: calc(var(--nav-h, 60px) + 8px);
   background:
     radial-gradient(circle at 12% 18%, rgba(129, 140, 248, 0.25), transparent 55%),
     radial-gradient(circle at 85% 12%, rgba(59, 130, 246, 0.22), transparent 52%),

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
         -webkit-font-smoothing: antialiased;
         position: relative;
         overflow-x: hidden;
+        padding-top: calc(var(--nav-h, 60px) + 8px);
       }
 
       body::before,
@@ -108,7 +109,7 @@
 
       .page-shell {
         width: var(--page-max-width);
-        margin: calc(var(--nav-h, 74px) + 48px) auto 0;
+        margin: 0 auto;
         display: grid;
         gap: clamp(40px, 5vw, 72px);
       }
@@ -118,7 +119,7 @@
         display: grid;
         grid-template-columns: 1fr;
         gap: clamp(28px, 5vw, 52px);
-        margin-top: clamp(24px, 6vw, 72px);
+        margin-top: clamp(12px, 4vw, 40px);
 
         padding: clamp(22px, 4.8vw, 52px) clamp(36px, 6vw, 68px)
           clamp(48px, 6vw, 72px);
@@ -976,7 +977,7 @@
 
       @media (max-width: 840px) {
         .page-shell {
-          margin: calc(var(--nav-h, 74px) + 36px) auto 0;
+          margin: 0 auto;
         }
 
         .quick-links {


### PR DESCRIPTION
## Summary
- reduce el espacio superior global aplicado al cuerpo para acercar el contenido a la navegación
- ajusta los márgenes del contenedor principal y la tarjeta hero para que el contenido aparezca antes en la página de inicio

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d07ec0803883258eb62744b3d76fe1