### PR TITLE
Actualizar branding del navbar

### DIFF
--- a/Foro.html
+++ b/Foro.html
@@ -48,13 +48,11 @@
 
                 <span class="qs-title">Calidad de Software</span>
 
-                <span class="qs-subtitle">Campus QS</span>
+                <span class="qs-subtitle">ITSON</span>
 
               </span>
 
             </a>
-
-            <span class="qs-chip">Edición 2024</span>
 
           </div>
 

--- a/asistencia.html
+++ b/asistencia.html
@@ -104,13 +104,11 @@
 
                 <span class="qs-title">Calidad de Software</span>
 
-                <span class="qs-subtitle">Campus QS</span>
+                <span class="qs-subtitle">ITSON</span>
 
               </span>
 
             </a>
-
-            <span class="qs-chip">Edición 2024</span>
 
           </div>
 

--- a/calificaciones.html
+++ b/calificaciones.html
@@ -274,13 +274,11 @@
 
                 <span class="qs-title">Calidad de Software</span>
 
-                <span class="qs-subtitle">Campus QS</span>
+                <span class="qs-subtitle">ITSON</span>
 
               </span>
 
             </a>
-
-            <span class="qs-chip">Edición 2024</span>
 
           </div>
 

--- a/index.html
+++ b/index.html
@@ -1095,8 +1095,6 @@
 
             </a>
 
-            <span class="qs-chip">Edición 2025</span>
-
           </div>
 
           <button

--- a/js/layout.js
+++ b/js/layout.js
@@ -122,10 +122,9 @@ function buildNavTemplate(basePath) {
             <span class="qs-logo" aria-hidden="true">QS</span>
             <span class="qs-brand-text">
               <span class="qs-title">Calidad de Software</span>
-              <span class="qs-subtitle">Campus QS</span>
+              <span class="qs-subtitle">ITSON</span>
             </span>
           </a>
-          <span class="qs-chip">Edicion 2024</span>
         </div>
         <button class="qs-menu-toggle" type="button" aria-expanded="false" aria-controls="qs-nav-links">
           <span class="qs-menu-icon" aria-hidden="true"></span>

--- a/materiales.html
+++ b/materiales.html
@@ -102,9 +102,11 @@
       .form-input,
       .form-select,
       .form-textarea {
-        width: 100%;
-        padding: 0.75rem;
-        border: 2px solid #e2e8f0;
+                <span class="qs-title">Calidad de Software</span>
+                <span class="qs-subtitle">ITSON</span>
+              </span>
+            </a>
+          </div>
         border-radius: 0.5rem;
         font-size: 1rem;
       }

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -151,9 +151,11 @@
       }
 
       .rubric-table {
-        background: white;
-        border-radius: 1rem;
-        overflow: hidden;
+                <span class="qs-title">Calidad de Software</span>
+                <span class="qs-subtitle">ITSON</span>
+              </span>
+            </a>
+          </div>
         box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
       }
 

--- a/sesion45.html
+++ b/sesion45.html
@@ -102,10 +102,9 @@
               <span class="qs-logo" aria-hidden="true">QS</span>
               <span class="qs-brand-text">
                 <span class="qs-title">Calidad de Software</span>
-                <span class="qs-subtitle">Campus QS</span>
+                <span class="qs-subtitle">ITSON</span>
               </span>
             </a>
-            <span class="qs-chip">Edición 2024</span>
           </div>
           <button
             class="qs-menu-toggle"


### PR DESCRIPTION
## Summary
- replace the navigation subtitle with the new ITSON label across shared markup
- remove the Edición chip from the navbar template and page fallbacks

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d0839bb36c8325a3ad2f78ccaddeeb