### PR TITLE
Adjust student uploads header width and remove insight panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@
       .student-uploads__header {
         display: grid;
         gap: 12px;
-        max-width: 620px;
+        width: 100%;
       }
 
       .student-uploads__eyebrow {
@@ -1217,29 +1217,6 @@
           </div>
         </a>
       </section>
-
-      <section class="insight-panels" aria-label="Indicadores destacados">
-        <article class="insight-card">
-          <h3 class="insight-card__title">Checklist siempre actualizado</h3>
-          <p class="insight-card__description">
-            Identifica qué sesiones ya completaste y cuáles están en curso con un vistazo rápido al panel principal.
-          </p>
-        </article>
-        <article class="insight-card">
-          <h3 class="insight-card__title">Materiales en un clic</h3>
-          <p class="insight-card__description">
-            Descarga guías, plantillas y rúbricas sincronizadas con cada sesión del programa.
-          </p>
-        </article>
-        <article class="insight-card">
-          <h3 class="insight-card__title">Retroalimentación accionable</h3>
-          <p class="insight-card__description">
-            Consulta comentarios y calificaciones del equipo docente para impulsar tu siguiente entrega.
-          </p>
-        </article>
-      </section>
-
-
 
       <div class="dashboard-grid">
 


### PR DESCRIPTION
## Summary
- allow the student uploads header block to span the full container width
- remove the featured insight panels section from the dashboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d08588c06c8325aef44f18500ee066