### PR TITLE
Oculta navegación embebida en sesiones

### DIFF
--- a/sesion10.html
+++ b/sesion10.html
@@ -1057,7 +1057,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
       <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
       <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>

--- a/sesion11.html
+++ b/sesion11.html
@@ -1316,7 +1316,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
       <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
       <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>

--- a/sesion12.html
+++ b/sesion12.html
@@ -1099,7 +1099,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
       <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
       <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>

--- a/sesion15.html
+++ b/sesion15.html
@@ -872,7 +872,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
       <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
       <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>

--- a/sesion16.html
+++ b/sesion16.html
@@ -1822,7 +1822,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
       <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
       <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>

--- a/sesion17.html
+++ b/sesion17.html
@@ -823,7 +823,7 @@
         <div class="indicator" onclick="goToSlide(5)"></div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="previousSlide()">
           ← Anterior
         </button>

--- a/sesion18.html
+++ b/sesion18.html
@@ -878,7 +878,7 @@
         <div class="indicator" onclick="goToSlide(4)"></div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="previousSlide()">
           ← Anterior
         </button>

--- a/sesion19.html
+++ b/sesion19.html
@@ -980,7 +980,7 @@
         <div class="indicator" onclick="goToSlide(4)"></div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="previousSlide()">
           ← Anterior
         </button>

--- a/sesion20.html
+++ b/sesion20.html
@@ -1250,7 +1250,7 @@
         <div class="indicator" onclick="goToSlide(3)"></div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="previousSlide()">
           ← Anterior
         </button>

--- a/sesion21.html
+++ b/sesion21.html
@@ -846,7 +846,7 @@
         </div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
           ← Anterior
         </button>

--- a/sesion22.html
+++ b/sesion22.html
@@ -651,7 +651,7 @@
         </div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
           ← Anterior
         </button>

--- a/sesion23.html
+++ b/sesion23.html
@@ -1475,7 +1475,7 @@
         </div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
           ← Anterior
         </button>

--- a/sesion24.html
+++ b/sesion24.html
@@ -1530,7 +1530,7 @@
         </div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
           ← Anterior
         </button>

--- a/sesion25.html
+++ b/sesion25.html
@@ -1506,7 +1506,7 @@
         </div>
       </div>
 
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
           ← Anterior
         </button>

--- a/sesion26.html
+++ b/sesion26.html
@@ -263,7 +263,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion27.html
+++ b/sesion27.html
@@ -261,7 +261,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion28.html
+++ b/sesion28.html
@@ -404,7 +404,7 @@
             Diapositiva <span id="currentSlide">1</span> de 4
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion29.html
+++ b/sesion29.html
@@ -274,7 +274,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion3.html
+++ b/sesion3.html
@@ -1538,7 +1538,7 @@
       </div>
 
       <!-- Navigation Controls -->
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" onclick="previousSlide()">
           ⬅️ Anterior
         </button>

--- a/sesion30.html
+++ b/sesion30.html
@@ -306,7 +306,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion31.html
+++ b/sesion31.html
@@ -326,7 +326,7 @@
             Diapositiva <span id="currentSlide">1</span> de 4
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion32.html
+++ b/sesion32.html
@@ -443,7 +443,7 @@
             Diapositiva <span id="currentSlide">1</span> de 6
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion33.html
+++ b/sesion33.html
@@ -300,7 +300,7 @@
             Diapositiva <span id="currentSlide">1</span> de 4
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion34.html
+++ b/sesion34.html
@@ -323,7 +323,7 @@
             Diapositiva <span id="currentSlide">1</span> de 4
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion37.html
+++ b/sesion37.html
@@ -653,7 +653,7 @@
     </div>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
         ← Anterior
       </button>

--- a/sesion38.html
+++ b/sesion38.html
@@ -1069,7 +1069,7 @@
     </div>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
         ← Anterior
       </button>

--- a/sesion39.html
+++ b/sesion39.html
@@ -1051,7 +1051,7 @@
     </div>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
         ← Anterior
       </button>

--- a/sesion4.html
+++ b/sesion4.html
@@ -1056,7 +1056,7 @@
       </div>
 
       <!-- Navigation Controls -->
-      <div class="navigation">
+      <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" onclick="previousSlide()">
           ⬅️ Anterior
         </button>

--- a/sesion40.html
+++ b/sesion40.html
@@ -247,7 +247,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 4</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion41.html
+++ b/sesion41.html
@@ -256,7 +256,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 4</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion42.html
+++ b/sesion42.html
@@ -359,7 +359,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 5</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion43.html
+++ b/sesion43.html
@@ -293,7 +293,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 6</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion44.html
+++ b/sesion44.html
@@ -286,7 +286,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 5</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion5.html
+++ b/sesion5.html
@@ -804,7 +804,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
         <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
         <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
         <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>

--- a/sesion6.html
+++ b/sesion6.html
@@ -367,7 +367,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
+        <div class="flex space-x-2" hidden aria-hidden="true">
           <button
             onclick="previousSlide()"
             id="prevBtn"

--- a/sesion7.html
+++ b/sesion7.html
@@ -1029,7 +1029,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
       <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
       <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>

--- a/sesion8.html
+++ b/sesion8.html
@@ -908,7 +908,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
       <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
       <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>

--- a/sesion9.html
+++ b/sesion9.html
@@ -903,7 +903,7 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
+    <div class="navigation" hidden aria-hidden="true">
       <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
       <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
       <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>


### PR DESCRIPTION
## Summary
- marca como ocultos los botones de navegación integrados en las diferentes sesiones para que no se dupliquen con los del layout
- mantiene los elementos originales en el DOM para que el asistente de navegación del layout siga detectando los estados de los slides

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68d0a069cb7c83259e0489be7a3426b3