### PR TITLE
Remove embedded slide navigation and create layout sentinels

### DIFF
--- a/sesion10.html
+++ b/sesion10.html
@@ -1057,13 +1057,23 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       const totalSlides = 4;
       let currentHighlightedPhase = null;
@@ -1096,15 +1106,12 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
-
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {
@@ -1199,6 +1206,13 @@
           });
         });
       });
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", function (e) {

--- a/sesion11.html
+++ b/sesion11.html
@@ -1316,13 +1316,23 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       const totalSlides = 4;
 
@@ -1354,15 +1364,12 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
-
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {
@@ -1406,6 +1413,13 @@
             });
           }
         }, 300);
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation

--- a/sesion12.html
+++ b/sesion12.html
@@ -1099,13 +1099,23 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       const totalSlides = 4;
 
@@ -1137,15 +1147,12 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
-
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {
@@ -1206,6 +1213,13 @@
         setTimeout(() => {
           element.style.animation = "pulse 1.5s ease-in-out";
         }, 10);
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation

--- a/sesion15.html
+++ b/sesion15.html
@@ -872,13 +872,23 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       const totalSlides = 3;
 
@@ -910,15 +920,12 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
-
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {
@@ -973,6 +980,13 @@
         setTimeout(() => {
           element.style.animation = "pulse 1.5s ease-in-out";
         }, 10);
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation

--- a/sesion16.html
+++ b/sesion16.html
@@ -1822,13 +1822,23 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       const totalSlides = 5;
 
@@ -1860,15 +1870,12 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
-
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {
@@ -1963,6 +1970,13 @@
         setTimeout(() => {
           element.style.animation = "pulse 1s ease-in-out";
         }, 10);
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation

--- a/sesion17.html
+++ b/sesion17.html
@@ -822,18 +822,26 @@
         <div class="indicator" onclick="goToSlide(4)"></div>
         <div class="indicator" onclick="goToSlide(5)"></div>
       </div>
-
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="previousSlide()">
-          ← Anterior
-        </button>
-        <button class="nav-button" id="nextBtn" onclick="nextSlide()">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const indicators = document.querySelectorAll(".indicator");
@@ -853,11 +861,16 @@
           indicator.classList.toggle("active", index === currentSlideIndex);
         });
 
-        document.getElementById("currentSlide").textContent =
-          currentSlideIndex + 1;
-        document.getElementById("prevBtn").disabled = currentSlideIndex === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlideIndex === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = currentSlideIndex + 1;
+        }
+
+        if (prevBtn) {
+          prevBtn.disabled = currentSlideIndex === 0;
+        }
+        if (nextBtn) {
+          nextBtn.disabled = currentSlideIndex === totalSlides - 1;
+        }
       }
 
       function nextSlide() {
@@ -877,6 +890,29 @@
       function goToSlide(index) {
         currentSlideIndex = index;
         updateSlideDisplay();
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion18.html
+++ b/sesion18.html
@@ -877,18 +877,26 @@
         <div class="indicator" onclick="goToSlide(3)"></div>
         <div class="indicator" onclick="goToSlide(4)"></div>
       </div>
-
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="previousSlide()">
-          ← Anterior
-        </button>
-        <button class="nav-button" id="nextBtn" onclick="nextSlide()">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const indicators = document.querySelectorAll(".indicator");
@@ -912,11 +920,16 @@
           indicator.classList.toggle("active", index === currentSlideIndex);
         });
 
-        document.getElementById("currentSlide").textContent =
-          currentSlideIndex + 1;
-        document.getElementById("prevBtn").disabled = currentSlideIndex === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlideIndex === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = currentSlideIndex + 1;
+        }
+
+        if (prevBtn) {
+          prevBtn.disabled = currentSlideIndex === 0;
+        }
+        if (nextBtn) {
+          nextBtn.disabled = currentSlideIndex === totalSlides - 1;
+        }
       }
 
       function nextSlide() {
@@ -936,6 +949,29 @@
       function goToSlide(index) {
         currentSlideIndex = index;
         updateSlideDisplay();
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion19.html
+++ b/sesion19.html
@@ -979,18 +979,26 @@
         <div class="indicator" onclick="goToSlide(3)"></div>
         <div class="indicator" onclick="goToSlide(4)"></div>
       </div>
-
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="previousSlide()">
-          ← Anterior
-        </button>
-        <button class="nav-button" id="nextBtn" onclick="nextSlide()">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const indicators = document.querySelectorAll(".indicator");
@@ -1014,11 +1022,16 @@
           indicator.classList.toggle("active", index === currentSlideIndex);
         });
 
-        document.getElementById("currentSlide").textContent =
-          currentSlideIndex + 1;
-        document.getElementById("prevBtn").disabled = currentSlideIndex === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlideIndex === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = currentSlideIndex + 1;
+        }
+
+        if (prevBtn) {
+          prevBtn.disabled = currentSlideIndex === 0;
+        }
+        if (nextBtn) {
+          nextBtn.disabled = currentSlideIndex === totalSlides - 1;
+        }
       }
 
       function nextSlide() {
@@ -1038,6 +1051,29 @@
       function goToSlide(index) {
         currentSlideIndex = index;
         updateSlideDisplay();
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion20.html
+++ b/sesion20.html
@@ -1249,18 +1249,26 @@
         <div class="indicator" onclick="goToSlide(2)"></div>
         <div class="indicator" onclick="goToSlide(3)"></div>
       </div>
-
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="previousSlide()">
-          ← Anterior
-        </button>
-        <button class="nav-button" id="nextBtn" onclick="nextSlide()">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const indicators = document.querySelectorAll(".indicator");
@@ -1283,11 +1291,16 @@
           indicator.classList.toggle("active", index === currentSlideIndex);
         });
 
-        document.getElementById("currentSlide").textContent =
-          currentSlideIndex + 1;
-        document.getElementById("prevBtn").disabled = currentSlideIndex === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlideIndex === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = currentSlideIndex + 1;
+        }
+
+        if (prevBtn) {
+          prevBtn.disabled = currentSlideIndex === 0;
+        }
+        if (nextBtn) {
+          nextBtn.disabled = currentSlideIndex === totalSlides - 1;
+        }
       }
 
       function nextSlide() {
@@ -1307,6 +1320,29 @@
       function goToSlide(index) {
         currentSlideIndex = index;
         updateSlideDisplay();
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion21.html
+++ b/sesion21.html
@@ -846,20 +846,27 @@
         </div>
       </div>
 
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">5</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
       </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
@@ -870,9 +877,12 @@
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({
@@ -887,6 +897,29 @@
           currentSlideIndex = newIndex;
           showSlide(currentSlideIndex);
         }
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion22.html
+++ b/sesion22.html
@@ -651,20 +651,27 @@
         </div>
       </div>
 
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">4</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
       </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
@@ -675,9 +682,12 @@
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({
@@ -692,6 +702,29 @@
           currentSlideIndex = newIndex;
           showSlide(currentSlideIndex);
         }
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion23.html
+++ b/sesion23.html
@@ -1475,20 +1475,27 @@
         </div>
       </div>
 
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">4</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
       </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
@@ -1499,9 +1506,12 @@
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({
@@ -1516,6 +1526,29 @@
           currentSlideIndex = newIndex;
           showSlide(currentSlideIndex);
         }
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion24.html
+++ b/sesion24.html
@@ -1530,20 +1530,27 @@
         </div>
       </div>
 
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">4</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
       </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
@@ -1554,9 +1561,12 @@
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({
@@ -1571,6 +1581,29 @@
           currentSlideIndex = newIndex;
           showSlide(currentSlideIndex);
         }
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion25.html
+++ b/sesion25.html
@@ -1506,20 +1506,27 @@
         </div>
       </div>
 
-      <div class="navigation">
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">4</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
       </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
@@ -1530,9 +1537,12 @@
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({
@@ -1547,6 +1557,29 @@
           currentSlideIndex = newIndex;
           showSlide(currentSlideIndex);
         }
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion26.html
+++ b/sesion26.html
@@ -263,22 +263,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1337,6 +1322,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 5;
       let brainstormTimerInterval = null;
@@ -1349,30 +1352,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -1444,6 +1446,29 @@
 
       // Initialize
       showSlide(0);
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", (e) => {

--- a/sesion27.html
+++ b/sesion27.html
@@ -261,22 +261,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1208,6 +1193,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 5;
       let debateTimerInterval = null;
@@ -1222,30 +1225,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -1418,6 +1420,29 @@
 
       // Initialize
       showSlide(0);
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", (e) => {

--- a/sesion28.html
+++ b/sesion28.html
@@ -404,22 +404,7 @@
             Diapositiva <span id="currentSlide">1</span> de 4
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1354,6 +1339,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 4;
       let discussionTimerInterval = null;
@@ -1366,30 +1369,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -2197,6 +2199,29 @@
 
       function closeModal() {
         document.getElementById("detailModal").classList.add("hidden");
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion29.html
+++ b/sesion29.html
@@ -274,22 +274,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1525,6 +1510,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 5;
       let caseTimerInterval = null;
@@ -1537,30 +1540,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -1652,6 +1654,29 @@
 
       // Initialize
       showSlide(0);
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", (e) => {

--- a/sesion3.html
+++ b/sesion3.html
@@ -1538,16 +1538,25 @@
       </div>
 
       <!-- Navigation Controls -->
-      <div class="navigation">
-        <button class="nav-button" onclick="previousSlide()">
-          ⬅️ Anterior
-        </button>
-        <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-        <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-      </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
 
       // Initialize the presentation
@@ -1584,14 +1593,21 @@
       }
 
       function updateSlideNavigation() {
-        document
-          .querySelectorAll(".slide-nav-button")
-          .forEach((button, index) => {
-            button.classList.remove("active");
-            if (index + 1 === currentSlide) {
-              button.classList.add("active");
-            }
-          });
+        const navButtons = document.querySelectorAll(".slide-nav-button");
+        navButtons.forEach((button, index) => {
+          button.classList.remove("active");
+          if (index + 1 === currentSlide) {
+            button.classList.add("active");
+          }
+        });
+
+        const totalSlides = document.querySelectorAll(".slide").length;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function toggleCharacteristic(characteristic) {
@@ -1650,6 +1666,13 @@
         document.querySelectorAll(".argument-details").forEach((el) => {
           el.classList.remove("active");
         });
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation

--- a/sesion30.html
+++ b/sesion30.html
@@ -306,22 +306,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1473,6 +1458,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 5;
       let debateTimerInterval = null;
@@ -1486,30 +1489,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -1632,6 +1634,29 @@
 
       // Initialize
       showSlide(0);
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", (e) => {

--- a/sesion31.html
+++ b/sesion31.html
@@ -326,22 +326,7 @@
             Diapositiva <span id="currentSlide">1</span> de 4
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1220,6 +1205,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 4;
       let debateTimerInterval = null;
@@ -1233,30 +1236,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -1367,6 +1369,29 @@
 
       // Initialize
       showSlide(0);
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", (e) => {

--- a/sesion32.html
+++ b/sesion32.html
@@ -443,22 +443,7 @@
             Diapositiva <span id="currentSlide">1</span> de 6
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -2038,6 +2023,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 6;
       let brainstormTimerInterval = null;
@@ -2051,30 +2054,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -2314,6 +2316,29 @@
 
       // Initialize
       showSlide(0);
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", (e) => {

--- a/sesion33.html
+++ b/sesion33.html
@@ -300,22 +300,7 @@
             Diapositiva <span id="currentSlide">1</span> de 4
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1652,6 +1637,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 4;
       let caseTimerInterval = null;
@@ -1665,30 +1668,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -2181,6 +2183,29 @@
 
       // Initialize
       showSlide(0);
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", (e) => {

--- a/sesion34.html
+++ b/sesion34.html
@@ -323,22 +323,7 @@
             Diapositiva <span id="currentSlide">1</span> de 4
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1724,6 +1709,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 4;
       let debateTimerInterval = null;
@@ -1737,30 +1740,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -1876,6 +1878,29 @@
 
       // Initialize
       showSlide(0);
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
+      }
 
       // Keyboard navigation
       document.addEventListener("keydown", (e) => {

--- a/sesion37.html
+++ b/sesion37.html
@@ -653,15 +653,6 @@
     </div>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
-        ← Anterior
-      </button>
-      <button class="nav-btn" onclick="nextSlide()" id="nextBtn">
-        Siguiente →
-      </button>
-    </div>
-
     <!-- Slide Indicators -->
     <div class="slide-indicator">
       <div class="indicator-dot active" onclick="goToSlide(0)"></div>
@@ -671,6 +662,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlide = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
@@ -688,8 +697,8 @@
         slides[currentSlide].classList.add("active");
 
         // Update navigation buttons
-        document.getElementById("prevBtn").disabled = currentSlide === 0;
-        document.getElementById("nextBtn").disabled =
+        prevBtn.disabled = currentSlide === 0;
+        nextBtn.disabled =
           currentSlide === totalSlides - 1;
 
         // Update indicators
@@ -760,6 +769,36 @@
         } else {
           timerElement.style.background = "#10b981";
         }
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion38.html
+++ b/sesion38.html
@@ -1069,15 +1069,6 @@
     </div>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
-        ← Anterior
-      </button>
-      <button class="nav-btn" onclick="nextSlide()" id="nextBtn">
-        Siguiente →
-      </button>
-    </div>
-
     <!-- Slide Indicators -->
     <div class="slide-indicator">
       <div class="indicator-dot active" onclick="goToSlide(0)"></div>
@@ -1087,6 +1078,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlide = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
@@ -1104,8 +1113,8 @@
         slides[currentSlide].classList.add("active");
 
         // Update navigation buttons
-        document.getElementById("prevBtn").disabled = currentSlide === 0;
-        document.getElementById("nextBtn").disabled =
+        prevBtn.disabled = currentSlide === 0;
+        nextBtn.disabled =
           currentSlide === totalSlides - 1;
 
         // Update indicators
@@ -1192,6 +1201,36 @@
 
       function toggleCheck(element) {
         element.classList.toggle("checked");
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion39.html
+++ b/sesion39.html
@@ -1051,15 +1051,6 @@
     </div>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
-        ← Anterior
-      </button>
-      <button class="nav-btn" onclick="nextSlide()" id="nextBtn">
-        Siguiente →
-      </button>
-    </div>
-
     <!-- Slide Indicators -->
     <div class="slide-indicator">
       <div class="indicator-dot active" onclick="goToSlide(0)"></div>
@@ -1069,6 +1060,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlide = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
@@ -1086,8 +1095,8 @@
         slides[currentSlide].classList.add("active");
 
         // Update navigation buttons
-        document.getElementById("prevBtn").disabled = currentSlide === 0;
-        document.getElementById("nextBtn").disabled =
+        prevBtn.disabled = currentSlide === 0;
+        nextBtn.disabled =
           currentSlide === totalSlides - 1;
 
         // Update indicators
@@ -1174,6 +1183,36 @@
 
       function toggleCheck(element) {
         element.classList.toggle("checked");
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion4.html
+++ b/sesion4.html
@@ -1056,16 +1056,25 @@
       </div>
 
       <!-- Navigation Controls -->
-      <div class="navigation">
-        <button class="nav-button" onclick="previousSlide()">
-          ⬅️ Anterior
-        </button>
-        <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-        <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-      </div>
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       let timerInterval = null;
 
@@ -1228,6 +1237,13 @@
 
         updateTimer();
         timerInterval = setInterval(updateTimer, 1000);
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation

--- a/sesion40.html
+++ b/sesion40.html
@@ -247,7 +247,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 4</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion41.html
+++ b/sesion41.html
@@ -256,7 +256,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 4</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion42.html
+++ b/sesion42.html
@@ -359,7 +359,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 5</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion43.html
+++ b/sesion43.html
@@ -293,7 +293,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 6</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion44.html
+++ b/sesion44.html
@@ -286,7 +286,7 @@
             </h1>
             <span class="text-sm text-gray-600" id="slide-counter">1 / 5</span>
           </div>
-          <div class="flex space-x-2">
+          <div class="flex space-x-2" hidden aria-hidden="true">
             <button
               onclick="previousSlide()"
               class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"

--- a/sesion5.html
+++ b/sesion5.html
@@ -804,14 +804,24 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-        <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-        <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-        <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
-        let currentSlide = 1;
+        const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
+      let currentSlide = 1;
         const totalSlides = 4;
         
         function updateSlideCounter() {
@@ -857,7 +867,14 @@
             showSlide(1);
         }
         
-        // Keyboard navigation
+        if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
+      }
+
+      // Keyboard navigation
         document.addEventListener('keydown', function(e) {
             if (e.key === 'ArrowLeft') {
                 previousSlide();

--- a/sesion6.html
+++ b/sesion6.html
@@ -367,22 +367,7 @@
             Diapositiva <span id="currentSlide">1</span> de 5
           </span>
         </div>
-        <div class="flex space-x-2">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
-        </div>
+
       </div>
       <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
         <div
@@ -1357,6 +1342,24 @@
     </div>
 
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevBtn = ensureLayoutNavButton("prevBtn");
+      const nextBtn = ensureLayoutNavButton("nextBtn");
+      const slideCounter = document.getElementById("currentSlide");
+
+
       let currentSlideIndex = 0;
       const totalSlides = 5;
       let selectedApp = null;
@@ -1533,30 +1536,29 @@
 
         document.getElementById(`slide${index + 1}`).classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (slideCounter) {
+          slideCounter.textContent = index + 1;
+        }
+
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === totalSlides - 1;
 
         const progress = ((index + 1) / totalSlides) * 100;
         document.getElementById("progressBar").style.width = progress + "%";
 
         if (index === 0) {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("prevBtn")
+          prevBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
 
         if (index === totalSlides - 1) {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.add("opacity-50", "cursor-not-allowed");
         } else {
-          document
-            .getElementById("nextBtn")
+          nextBtn
             .classList.remove("opacity-50", "cursor-not-allowed");
         }
       }
@@ -2159,6 +2161,29 @@ Copia este contenido y adáptalo a tu presentación.
 
       function closeCalculator() {
         document.getElementById("calculatorModal").classList.add("hidden");
+      }
+
+      const handleLayoutPrev = () => {
+        if (typeof previousSlide === "function") {
+          previousSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(-1);
+        }
+      };
+
+      const handleLayoutNext = () => {
+        if (typeof nextSlide === "function") {
+          nextSlide();
+        } else if (typeof changeSlide === "function") {
+          changeSlide(1);
+        }
+      };
+
+      if (prevBtn) {
+        prevBtn.addEventListener("click", handleLayoutPrev);
+      }
+      if (nextBtn) {
+        nextBtn.addEventListener("click", handleLayoutNext);
       }
 
       // Keyboard navigation

--- a/sesion7.html
+++ b/sesion7.html
@@ -1029,13 +1029,23 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       const totalSlides = 4;
 
@@ -1067,15 +1077,12 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
-
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {
@@ -1121,6 +1128,13 @@
           answer.classList.add("show");
           card.classList.add("revealed");
         }
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation

--- a/sesion8.html
+++ b/sesion8.html
@@ -908,13 +908,23 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       const totalSlides = 4;
       let timerInterval;
@@ -948,15 +958,12 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
-
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {
@@ -1023,6 +1030,13 @@
           timerElement.style.background =
             "linear-gradient(135deg, #ef4444, #dc2626)";
         }
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation

--- a/sesion9.html
+++ b/sesion9.html
@@ -903,13 +903,23 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation">
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
+      const ensureLayoutNavButton = (id) => {
+        let button = document.getElementById(id);
+        if (button) return button;
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = id;
+        button.hidden = true;
+        button.setAttribute("aria-hidden", "true");
+        button.tabIndex = -1;
+        document.body.appendChild(button);
+        return button;
+      };
+
+      const prevNavButton = ensureLayoutNavButton("prevBtn");
+      const nextNavButton = ensureLayoutNavButton("nextBtn");
+
       let currentSlide = 1;
       const totalSlides = 4;
 
@@ -941,15 +951,12 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
-
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        if (prevNavButton) {
+          prevNavButton.disabled = currentSlide === 1;
+        }
+        if (nextNavButton) {
+          nextNavButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {
@@ -966,6 +973,13 @@
 
       function resetAll() {
         showSlide(1);
+      }
+
+      if (prevNavButton) {
+        prevNavButton.addEventListener("click", previousSlide);
+      }
+      if (nextNavButton) {
+        nextNavButton.addEventListener("click", nextSlide);
       }
 
       // Keyboard navigation


### PR DESCRIPTION
## Summary
- replace the inline navigation blocks from the session HTML decks with hidden sentinel buttons created through `ensureLayoutNavButton`
- update each slide script to disable those sentinels when boundaries are reached and to keep the layout slide counter in sync
- bind the sentinels to the existing slide functions (or `changeSlide`) so the layout-provided controls continue to drive navigation

## Testing
- not run (static HTML updates)


------
https://chatgpt.com/codex/tasks/task_e_68d0a069cb7c83259e0489be7a3426b3