### PR TITLE
Remove legacy slide nav controls from session pages

### DIFF
--- a/sesion10.html
+++ b/sesion10.html
@@ -60,46 +60,6 @@
         }
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 10px;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        padding: 15px 20px;
-        border-radius: 50px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        border: none;
-        padding: 12px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 14px;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(118, 75, 162, 0.3);
-      }
-
-      .nav-button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
-      }
-
-      .nav-button:disabled {
-        background: #9ca3af;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 20px;
@@ -1056,13 +1016,6 @@
       </div>
     </main>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
       let currentSlide = 1;
       const totalSlides = 4;
@@ -1096,15 +1049,20 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
+        const navigation = document.querySelector(".navigation");
+        if (!navigation) {
+          return;
+        }
 
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        const prevButton = navigation.querySelector("button:first-child");
+        const nextButton = navigation.querySelector("button:last-child");
+
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 1;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {

--- a/sesion11.html
+++ b/sesion11.html
@@ -60,46 +60,6 @@
         }
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 10px;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        padding: 15px 20px;
-        border-radius: 50px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        border: none;
-        padding: 12px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 14px;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(118, 75, 162, 0.3);
-      }
-
-      .nav-button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
-      }
-
-      .nav-button:disabled {
-        background: #9ca3af;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 20px;
@@ -1315,13 +1275,6 @@
       </div>
     </main>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
       let currentSlide = 1;
       const totalSlides = 4;
@@ -1354,15 +1307,20 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
+        const navigation = document.querySelector(".navigation");
+        if (!navigation) {
+          return;
+        }
 
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        const prevButton = navigation.querySelector("button:first-child");
+        const nextButton = navigation.querySelector("button:last-child");
+
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 1;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {

--- a/sesion12.html
+++ b/sesion12.html
@@ -61,46 +61,6 @@
         }
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 10px;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        padding: 15px 20px;
-        border-radius: 50px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        border: none;
-        padding: 12px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 14px;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(118, 75, 162, 0.3);
-      }
-
-      .nav-button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
-      }
-
-      .nav-button:disabled {
-        background: #9ca3af;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 20px;
@@ -1099,12 +1059,6 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
       let currentSlide = 1;
       const totalSlides = 4;
@@ -1137,15 +1091,20 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
+        const navigation = document.querySelector(".navigation");
+        if (!navigation) {
+          return;
+        }
 
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        const prevButton = navigation.querySelector("button:first-child");
+        const nextButton = navigation.querySelector("button:last-child");
+
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 1;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {

--- a/sesion15.html
+++ b/sesion15.html
@@ -61,46 +61,6 @@
         }
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 10px;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        padding: 15px 20px;
-        border-radius: 50px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        border: none;
-        padding: 12px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 14px;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(118, 75, 162, 0.3);
-      }
-
-      .nav-button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
-      }
-
-      .nav-button:disabled {
-        background: #9ca3af;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 20px;
@@ -871,13 +831,6 @@
       </div>
     </main>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
       let currentSlide = 1;
       const totalSlides = 3;
@@ -910,15 +863,20 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
+        const navigation = document.querySelector(".navigation");
+        if (!navigation) {
+          return;
+        }
 
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        const prevButton = navigation.querySelector("button:first-child");
+        const nextButton = navigation.querySelector("button:last-child");
+
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 1;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {

--- a/sesion16.html
+++ b/sesion16.html
@@ -61,46 +61,6 @@
         }
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 10px;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        padding: 15px 20px;
-        border-radius: 50px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        border: none;
-        padding: 12px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 14px;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(118, 75, 162, 0.3);
-      }
-
-      .nav-button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
-      }
-
-      .nav-button:disabled {
-        background: #9ca3af;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 20px;
@@ -1821,13 +1781,6 @@
       </div>
     </main>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
       let currentSlide = 1;
       const totalSlides = 5;
@@ -1860,15 +1813,20 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
+        const navigation = document.querySelector(".navigation");
+        if (!navigation) {
+          return;
+        }
 
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        const prevButton = navigation.querySelector("button:first-child");
+        const nextButton = navigation.querySelector("button:last-child");
+
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 1;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {

--- a/sesion17.html
+++ b/sesion17.html
@@ -221,41 +221,6 @@
         border-radius: 5px;
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 30px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 15px;
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: rgba(255, 255, 255, 0.9);
-        border: none;
-        padding: 15px 25px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-size: 16px;
-        font-weight: bold;
-        color: #667eea;
-        transition: all 0.3s ease;
-        backdrop-filter: blur(10px);
-      }
-
-      .nav-button:hover {
-        background: white;
-        transform: translateY(-2px);
-        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-      }
-
-      .nav-button:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        transform: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 30px;
@@ -823,14 +788,6 @@
         <div class="indicator" onclick="goToSlide(5)"></div>
       </div>
 
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="previousSlide()">
-          ← Anterior
-        </button>
-        <button class="nav-button" id="nextBtn" onclick="nextSlide()">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
@@ -838,6 +795,9 @@
       const slides = document.querySelectorAll(".slide");
       const indicators = document.querySelectorAll(".indicator");
       const totalSlides = slides.length;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
 
       function updateSlideDisplay() {
         slides.forEach((slide, index) => {
@@ -853,11 +813,15 @@
           indicator.classList.toggle("active", index === currentSlideIndex);
         });
 
-        document.getElementById("currentSlide").textContent =
-          currentSlideIndex + 1;
-        document.getElementById("prevBtn").disabled = currentSlideIndex === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlideIndex === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = currentSlideIndex + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = currentSlideIndex === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlideIndex === totalSlides - 1;
+        }
       }
 
       function nextSlide() {

--- a/sesion18.html
+++ b/sesion18.html
@@ -221,41 +221,6 @@
         border-radius: 5px;
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 30px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 15px;
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: rgba(255, 255, 255, 0.9);
-        border: none;
-        padding: 15px 25px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-size: 16px;
-        font-weight: bold;
-        color: #667eea;
-        transition: all 0.3s ease;
-        backdrop-filter: blur(10px);
-      }
-
-      .nav-button:hover {
-        background: white;
-        transform: translateY(-2px);
-        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-      }
-
-      .nav-button:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        transform: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 30px;
@@ -878,14 +843,6 @@
         <div class="indicator" onclick="goToSlide(4)"></div>
       </div>
 
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="previousSlide()">
-          ← Anterior
-        </button>
-        <button class="nav-button" id="nextBtn" onclick="nextSlide()">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
@@ -893,6 +850,9 @@
       const slides = document.querySelectorAll(".slide");
       const indicators = document.querySelectorAll(".indicator");
       const totalSlides = slides.length;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
 
       function updateSlideDisplay() {
         slides.forEach((slide, index) => {
@@ -912,11 +872,15 @@
           indicator.classList.toggle("active", index === currentSlideIndex);
         });
 
-        document.getElementById("currentSlide").textContent =
-          currentSlideIndex + 1;
-        document.getElementById("prevBtn").disabled = currentSlideIndex === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlideIndex === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = currentSlideIndex + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = currentSlideIndex === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlideIndex === totalSlides - 1;
+        }
       }
 
       function nextSlide() {

--- a/sesion19.html
+++ b/sesion19.html
@@ -259,41 +259,6 @@
         border-left: 8px solid #ffc107;
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 30px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 15px;
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: rgba(255, 255, 255, 0.9);
-        border: none;
-        padding: 15px 25px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-size: 16px;
-        font-weight: bold;
-        color: #1e3c72;
-        transition: all 0.3s ease;
-        backdrop-filter: blur(10px);
-      }
-
-      .nav-button:hover {
-        background: white;
-        transform: translateY(-2px);
-        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-      }
-
-      .nav-button:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        transform: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 30px;
@@ -980,14 +945,6 @@
         <div class="indicator" onclick="goToSlide(4)"></div>
       </div>
 
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="previousSlide()">
-          ← Anterior
-        </button>
-        <button class="nav-button" id="nextBtn" onclick="nextSlide()">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
@@ -995,6 +952,9 @@
       const slides = document.querySelectorAll(".slide");
       const indicators = document.querySelectorAll(".indicator");
       const totalSlides = slides.length;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
 
       function updateSlideDisplay() {
         slides.forEach((slide, index) => {
@@ -1014,11 +974,15 @@
           indicator.classList.toggle("active", index === currentSlideIndex);
         });
 
-        document.getElementById("currentSlide").textContent =
-          currentSlideIndex + 1;
-        document.getElementById("prevBtn").disabled = currentSlideIndex === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlideIndex === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = currentSlideIndex + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = currentSlideIndex === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlideIndex === totalSlides - 1;
+        }
       }
 
       function nextSlide() {

--- a/sesion20.html
+++ b/sesion20.html
@@ -309,41 +309,6 @@
         box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 30px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 15px;
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: rgba(255, 255, 255, 0.9);
-        border: none;
-        padding: 15px 25px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-size: 16px;
-        font-weight: bold;
-        color: #667eea;
-        transition: all 0.3s ease;
-        backdrop-filter: blur(10px);
-      }
-
-      .nav-button:hover {
-        background: white;
-        transform: translateY(-2px);
-        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
-      }
-
-      .nav-button:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        transform: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 30px;
@@ -1250,14 +1215,6 @@
         <div class="indicator" onclick="goToSlide(3)"></div>
       </div>
 
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="previousSlide()">
-          ← Anterior
-        </button>
-        <button class="nav-button" id="nextBtn" onclick="nextSlide()">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
@@ -1265,6 +1222,9 @@
       const slides = document.querySelectorAll(".slide");
       const indicators = document.querySelectorAll(".indicator");
       const totalSlides = slides.length;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
 
       function updateSlideDisplay() {
         slides.forEach((slide, index) => {
@@ -1283,11 +1243,15 @@
           indicator.classList.toggle("active", index === currentSlideIndex);
         });
 
-        document.getElementById("currentSlide").textContent =
-          currentSlideIndex + 1;
-        document.getElementById("prevBtn").disabled = currentSlideIndex === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlideIndex === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = currentSlideIndex + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = currentSlideIndex === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlideIndex === totalSlides - 1;
+        }
       }
 
       function nextSlide() {

--- a/sesion21.html
+++ b/sesion21.html
@@ -151,46 +151,6 @@
         margin-bottom: 15px;
       }
 
-      .navigation {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 20px 60px;
-        background: #f8f9fa;
-        border-top: 1px solid #e2e8f0;
-      }
-
-      .nav-button {
-        background: #667eea;
-        color: white;
-        border: none;
-        padding: 12px 24px;
-        border-radius: 8px;
-        cursor: pointer;
-        font-size: 1rem;
-        font-weight: 600;
-        transition: all 0.3s ease;
-      }
-
-      .nav-button:hover {
-        background: #5a67d8;
-        transform: translateY(-2px);
-      }
-
-      .nav-button:disabled {
-        background: #cbd5e0;
-        cursor: not-allowed;
-        transform: none;
-      }
-
-      .slide-counter {
-        background: #667eea;
-        color: white;
-        padding: 8px 16px;
-        border-radius: 20px;
-        font-weight: 600;
-      }
-
       .teacher-notes {
         background: #e6fffa;
         border: 2px solid #38b2ac;
@@ -443,10 +403,6 @@
         .dimensions-grid {
           grid-template-columns: 1fr;
           gap: 20px;
-        }
-
-        .navigation {
-          padding: 15px 30px;
         }
 
         .connection-header,
@@ -846,17 +802,6 @@
         </div>
       </div>
 
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">5</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
@@ -864,15 +809,28 @@
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
 
-      document.getElementById("totalSlides").textContent = totalSlides;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const totalSlideLabel = document.getElementById("totalSlides");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
+
+      if (totalSlideLabel) {
+        totalSlideLabel.textContent = totalSlides;
+      }
 
       function showSlide(index) {
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = index + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = index === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = index === totalSlides - 1;
+        }
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({

--- a/sesion22.html
+++ b/sesion22.html
@@ -91,46 +91,6 @@
         border-radius: 8px;
       }
 
-      .navigation {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 20px 60px;
-        background: #f8f9fa;
-        border-top: 1px solid #e2e8f0;
-      }
-
-      .nav-button {
-        background: #00c851;
-        color: white;
-        border: none;
-        padding: 12px 24px;
-        border-radius: 8px;
-        cursor: pointer;
-        font-size: 1rem;
-        font-weight: 600;
-        transition: all 0.3s ease;
-      }
-
-      .nav-button:hover {
-        background: #007e33;
-        transform: translateY(-2px);
-      }
-
-      .nav-button:disabled {
-        background: #cbd5e0;
-        cursor: not-allowed;
-        transform: none;
-      }
-
-      .slide-counter {
-        background: #00c851;
-        color: white;
-        padding: 8px 16px;
-        border-radius: 20px;
-        font-weight: 600;
-      }
-
       .teacher-notes {
         background: #e6fffa;
         border: 2px solid #00c851;
@@ -411,10 +371,6 @@
           gap: 20px;
         }
 
-        .navigation {
-          padding: 15px 30px;
-        }
-
         .category-content {
           margin-left: 0;
           margin-top: 20px;
@@ -649,16 +605,7 @@
             modelo que habla el idioma de los roles de una empresa."
           </p>
         </div>
-      </div>
-
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">4</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
+      </div>        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
           Siguiente →
         </button>
       </div>
@@ -668,16 +615,28 @@
       let currentSlideIndex = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const totalSlideLabel = document.getElementById("totalSlides");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
 
-      document.getElementById("totalSlides").textContent = totalSlides;
+      if (totalSlideLabel) {
+        totalSlideLabel.textContent = totalSlides;
+      }
 
       function showSlide(index) {
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = index + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = index === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = index === totalSlides - 1;
+        }
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({

--- a/sesion23.html
+++ b/sesion23.html
@@ -91,46 +91,6 @@
         border-radius: 8px;
       }
 
-      .navigation {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 20px 60px;
-        background: #f8f9fa;
-        border-top: 1px solid #e2e8f0;
-      }
-
-      .nav-button {
-        background: #667eea;
-        color: white;
-        border: none;
-        padding: 12px 24px;
-        border-radius: 8px;
-        cursor: pointer;
-        font-size: 1rem;
-        font-weight: 600;
-        transition: all 0.3s ease;
-      }
-
-      .nav-button:hover {
-        background: #5a67d8;
-        transform: translateY(-2px);
-      }
-
-      .nav-button:disabled {
-        background: #cbd5e0;
-        cursor: not-allowed;
-        transform: none;
-      }
-
-      .slide-counter {
-        background: #667eea;
-        color: white;
-        padding: 8px 16px;
-        border-radius: 20px;
-        font-weight: 600;
-      }
-
       .teacher-notes {
         background: #e6fffa;
         border: 2px solid #38b2ac;
@@ -852,10 +812,6 @@
           gap: 15px;
         }
 
-        .navigation {
-          padding: 15px 30px;
-        }
-
         .principle-header {
           flex-direction: column;
           text-align: center;
@@ -1475,17 +1431,6 @@
         </div>
       </div>
 
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">4</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
@@ -1493,15 +1438,28 @@
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
 
-      document.getElementById("totalSlides").textContent = totalSlides;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const totalSlideLabel = document.getElementById("totalSlides");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
+
+      if (totalSlideLabel) {
+        totalSlideLabel.textContent = totalSlides;
+      }
 
       function showSlide(index) {
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = index + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = index === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = index === totalSlides - 1;
+        }
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({

--- a/sesion24.html
+++ b/sesion24.html
@@ -91,46 +91,6 @@
         border-radius: 8px;
       }
 
-      .navigation {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 20px 60px;
-        background: #f8f9fa;
-        border-top: 1px solid #e2e8f0;
-      }
-
-      .nav-button {
-        background: #667eea;
-        color: white;
-        border: none;
-        padding: 12px 24px;
-        border-radius: 8px;
-        cursor: pointer;
-        font-size: 1rem;
-        font-weight: 600;
-        transition: all 0.3s ease;
-      }
-
-      .nav-button:hover {
-        background: #5a67d8;
-        transform: translateY(-2px);
-      }
-
-      .nav-button:disabled {
-        background: #cbd5e0;
-        cursor: not-allowed;
-        transform: none;
-      }
-
-      .slide-counter {
-        background: #667eea;
-        color: white;
-        padding: 8px 16px;
-        border-radius: 20px;
-        font-weight: 600;
-      }
-
       .teacher-notes {
         background: #e6fffa;
         border: 2px solid #38b2ac;
@@ -921,10 +881,6 @@
           font-size: 1.8rem;
         }
 
-        .navigation {
-          padding: 15px 30px;
-        }
-
         .breakdown-content {
           margin-left: 0;
           margin-top: 15px;
@@ -1530,17 +1486,6 @@
         </div>
       </div>
 
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">4</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
@@ -1548,15 +1493,28 @@
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
 
-      document.getElementById("totalSlides").textContent = totalSlides;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const totalSlideLabel = document.getElementById("totalSlides");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
+
+      if (totalSlideLabel) {
+        totalSlideLabel.textContent = totalSlides;
+      }
 
       function showSlide(index) {
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = index + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = index === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = index === totalSlides - 1;
+        }
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({

--- a/sesion25.html
+++ b/sesion25.html
@@ -91,46 +91,6 @@
         border-radius: 8px;
       }
 
-      .navigation {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 20px 60px;
-        background: #f8f9fa;
-        border-top: 1px solid #e2e8f0;
-      }
-
-      .nav-button {
-        background: #667eea;
-        color: white;
-        border: none;
-        padding: 12px 24px;
-        border-radius: 8px;
-        cursor: pointer;
-        font-size: 1rem;
-        font-weight: 600;
-        transition: all 0.3s ease;
-      }
-
-      .nav-button:hover {
-        background: #5a67d8;
-        transform: translateY(-2px);
-      }
-
-      .nav-button:disabled {
-        background: #cbd5e0;
-        cursor: not-allowed;
-        transform: none;
-      }
-
-      .slide-counter {
-        background: #667eea;
-        color: white;
-        padding: 8px 16px;
-        border-radius: 20px;
-        font-weight: 600;
-      }
-
       .teacher-notes {
         background: #e6fffa;
         border: 2px solid #38b2ac;
@@ -921,10 +881,6 @@
           font-size: 1.8rem;
         }
 
-        .navigation {
-          padding: 15px 30px;
-        }
-
         .breakdown-content {
           margin-left: 0;
           margin-top: 15px;
@@ -1506,17 +1462,6 @@
         </div>
       </div>
 
-      <div class="navigation" hidden>
-        <button class="nav-button" id="prevBtn" onclick="changeSlide(-1)">
-          ← Anterior
-        </button>
-        <div class="slide-counter">
-          <span id="currentSlide">1</span> / <span id="totalSlides">4</span>
-        </div>
-        <button class="nav-button" id="nextBtn" onclick="changeSlide(1)">
-          Siguiente →
-        </button>
-      </div>
     </div>
 
     <script>
@@ -1524,15 +1469,28 @@
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
 
-      document.getElementById("totalSlides").textContent = totalSlides;
+      const currentSlideLabel = document.getElementById("currentSlide");
+      const totalSlideLabel = document.getElementById("totalSlides");
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
+
+      if (totalSlideLabel) {
+        totalSlideLabel.textContent = totalSlides;
+      }
 
       function showSlide(index) {
         slides.forEach((slide) => slide.classList.remove("active"));
         slides[index].classList.add("active");
 
-        document.getElementById("currentSlide").textContent = index + 1;
-        document.getElementById("prevBtn").disabled = index === 0;
-        document.getElementById("nextBtn").disabled = index === totalSlides - 1;
+        if (currentSlideLabel) {
+          currentSlideLabel.textContent = index + 1;
+        }
+        if (prevButton) {
+          prevButton.disabled = index === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = index === totalSlides - 1;
+        }
 
         // Scroll to top smoothly when changing slides
         window.scrollTo({

--- a/sesion3.html
+++ b/sesion3.html
@@ -380,30 +380,6 @@
         animation: slideIn 0.5s ease;
       }
 
-      .navigation {
-        display: flex;
-        justify-content: center;
-        gap: 20px;
-        margin: 30px 0;
-      }
-
-      .nav-button {
-        background: white;
-        color: #667eea;
-        border: 2px solid #667eea;
-        padding: 12px 25px;
-        border-radius: 25px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        font-weight: bold;
-      }
-
-      .nav-button:hover {
-        background: #667eea;
-        color: white;
-        transform: translateY(-2px);
-      }
-
       /* Cause-Effect Styles */
       .cause-effect-item {
         display: flex;
@@ -1537,14 +1513,6 @@
         </div>
       </div>
 
-      <!-- Navigation Controls -->
-      <div class="navigation" hidden>
-        <button class="nav-button" onclick="previousSlide()">
-          ⬅️ Anterior
-        </button>
-        <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-        <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-      </div>
     </div>
 
     <script>

--- a/sesion37.html
+++ b/sesion37.html
@@ -256,41 +256,6 @@
         color: #9ca3af;
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 30px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 15px;
-        z-index: 1000;
-      }
-
-      .nav-btn {
-        background: rgba(255, 255, 255, 0.9);
-        border: none;
-        padding: 15px 25px;
-        border-radius: 50px;
-        cursor: pointer;
-        font-weight: 600;
-        color: #4f46e5;
-        transition: all 0.3s ease;
-        backdrop-filter: blur(10px);
-        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-      }
-
-      .nav-btn:hover {
-        background: white;
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
-      }
-
-      .nav-btn:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        transform: none;
-      }
-
       .slide-indicator {
         position: fixed;
         bottom: 100px;
@@ -495,10 +460,6 @@
           gap: 15px;
         }
 
-        .navigation {
-          bottom: 20px;
-        }
-
         .slide-indicator {
           bottom: 80px;
         }
@@ -652,16 +613,6 @@
       </div>
     </div>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
-        ← Anterior
-      </button>
-      <button class="nav-btn" onclick="nextSlide()" id="nextBtn">
-        Siguiente →
-      </button>
-    </div>
-
     <!-- Slide Indicators -->
     <div class="slide-indicator">
       <div class="indicator-dot active" onclick="goToSlide(0)"></div>
@@ -674,6 +625,8 @@
       let currentSlide = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
       let timerInterval;
       let timeLeft = 1200; // 20 minutes in seconds
       let isTimerRunning = false;
@@ -688,9 +641,12 @@
         slides[currentSlide].classList.add("active");
 
         // Update navigation buttons
-        document.getElementById("prevBtn").disabled = currentSlide === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlide === totalSlides - 1;
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides - 1;
+        }
 
         // Update indicators
         document.querySelectorAll(".indicator-dot").forEach((dot, index) => {

--- a/sesion38.html
+++ b/sesion38.html
@@ -588,42 +588,6 @@
         opacity: 0.9;
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 30px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 20px;
-        z-index: 1000;
-      }
-
-      .nav-btn {
-        background: rgba(255, 255, 255, 0.9);
-        backdrop-filter: blur(20px);
-        border: none;
-        padding: 15px 30px;
-        border-radius: 50px;
-        cursor: pointer;
-        font-weight: 600;
-        color: #667eea;
-        transition: all 0.3s ease;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        border: 2px solid rgba(255, 255, 255, 0.3);
-      }
-
-      .nav-btn:hover {
-        background: white;
-        transform: translateY(-3px);
-        box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
-      }
-
-      .nav-btn:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        transform: none;
-      }
-
       .slide-indicator {
         position: fixed;
         bottom: 100px;
@@ -720,10 +684,6 @@
 
         .gap-inputs {
           grid-template-columns: 1fr;
-        }
-
-        .navigation {
-          bottom: 20px;
         }
 
         .slide-indicator {
@@ -1068,16 +1028,6 @@
       </div>
     </div>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
-        ← Anterior
-      </button>
-      <button class="nav-btn" onclick="nextSlide()" id="nextBtn">
-        Siguiente →
-      </button>
-    </div>
-
     <!-- Slide Indicators -->
     <div class="slide-indicator">
       <div class="indicator-dot active" onclick="goToSlide(0)"></div>
@@ -1090,6 +1040,8 @@
       let currentSlide = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
       let timerInterval;
       let timeLeft = 1200; // 20 minutes in seconds
       let isTimerRunning = false;
@@ -1104,9 +1056,12 @@
         slides[currentSlide].classList.add("active");
 
         // Update navigation buttons
-        document.getElementById("prevBtn").disabled = currentSlide === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlide === totalSlides - 1;
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides - 1;
+        }
 
         // Update indicators
         document.querySelectorAll(".indicator-dot").forEach((dot, index) => {

--- a/sesion39.html
+++ b/sesion39.html
@@ -631,42 +631,6 @@
         background: rgba(255, 255, 255, 0.8);
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 30px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 20px;
-        z-index: 1000;
-      }
-
-      .nav-btn {
-        background: rgba(255, 255, 255, 0.9);
-        backdrop-filter: blur(20px);
-        border: none;
-        padding: 15px 30px;
-        border-radius: 50px;
-        cursor: pointer;
-        font-weight: 600;
-        color: #667eea;
-        transition: all 0.3s ease;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        border: 2px solid rgba(255, 255, 255, 0.3);
-      }
-
-      .nav-btn:hover {
-        background: white;
-        transform: translateY(-3px);
-        box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
-      }
-
-      .nav-btn:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        transform: none;
-      }
-
       .slide-indicator {
         position: fixed;
         bottom: 100px;
@@ -740,10 +704,6 @@
 
         .work-area {
           grid-template-rows: repeat(4, auto);
-        }
-
-        .navigation {
-          bottom: 20px;
         }
 
         .slide-indicator {
@@ -1050,16 +1010,6 @@
       </div>
     </div>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-btn" onclick="previousSlide()" id="prevBtn">
-        ← Anterior
-      </button>
-      <button class="nav-btn" onclick="nextSlide()" id="nextBtn">
-        Siguiente →
-      </button>
-    </div>
-
     <!-- Slide Indicators -->
     <div class="slide-indicator">
       <div class="indicator-dot active" onclick="goToSlide(0)"></div>
@@ -1072,6 +1022,8 @@
       let currentSlide = 0;
       const slides = document.querySelectorAll(".slide");
       const totalSlides = slides.length;
+      const prevButton = document.getElementById("prevBtn");
+      const nextButton = document.getElementById("nextBtn");
       let timerInterval;
       let timeLeft = 1200; // 20 minutes in seconds
       let isTimerRunning = false;
@@ -1086,9 +1038,12 @@
         slides[currentSlide].classList.add("active");
 
         // Update navigation buttons
-        document.getElementById("prevBtn").disabled = currentSlide === 0;
-        document.getElementById("nextBtn").disabled =
-          currentSlide === totalSlides - 1;
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 0;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides - 1;
+        }
 
         // Update indicators
         document.querySelectorAll(".indicator-dot").forEach((dot, index) => {

--- a/sesion4.html
+++ b/sesion4.html
@@ -268,30 +268,6 @@
         }
       }
 
-      .navigation {
-        display: flex;
-        justify-content: center;
-        gap: 20px;
-        margin: 30px 0;
-      }
-
-      .nav-button {
-        background: white;
-        color: #667eea;
-        border: 2px solid #667eea;
-        padding: 12px 25px;
-        border-radius: 25px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        font-weight: bold;
-      }
-
-      .nav-button:hover {
-        background: #667eea;
-        color: white;
-        transform: translateY(-2px);
-      }
-
       /* Slide Navigation */
       .slide-navigation {
         display: flex;
@@ -1055,14 +1031,6 @@
         </div>
       </div>
 
-      <!-- Navigation Controls -->
-      <div class="navigation" hidden>
-        <button class="nav-button" onclick="previousSlide()">
-          ⬅️ Anterior
-        </button>
-        <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-        <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-      </div>
     </div>
 
     <script>

--- a/sesion5.html
+++ b/sesion5.html
@@ -48,46 +48,6 @@
             50% { transform: scale(1.05); }
         }
         
-        .navigation {
-            position: fixed;
-            bottom: 20px;
-            left: 50%;
-            transform: translateX(-50%);
-            display: flex;
-            gap: 10px;
-            background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(10px);
-            padding: 15px 20px;
-            border-radius: 50px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-            z-index: 1000;
-        }
-        
-        .nav-button {
-            background: linear-gradient(135deg, #3b82f6, #8b5cf6);
-            color: white;
-            border: none;
-            padding: 12px 20px;
-            border-radius: 25px;
-            cursor: pointer;
-            font-weight: 600;
-            font-size: 14px;
-            transition: all 0.3s ease;
-            box-shadow: 0 4px 15px rgba(59, 130, 246, 0.3);
-        }
-        
-        .nav-button:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
-        }
-        
-        .nav-button:disabled {
-            background: #9ca3af;
-            cursor: not-allowed;
-            transform: none;
-            box-shadow: none;
-        }
-        
         .metric-card {
             background: white;
             border-radius: 1rem;
@@ -803,13 +763,6 @@
         </div>
     </main>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-        <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-        <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-        <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
         let currentSlide = 1;
         const totalSlides = 4;
@@ -834,11 +787,20 @@
         }
         
         function updateNavigationButtons() {
-            const prevButton = document.querySelector('.navigation button:first-child');
-            const nextButton = document.querySelector('.navigation button:last-child');
-            
-            prevButton.disabled = currentSlide === 1;
-            nextButton.disabled = currentSlide === totalSlides;
+            const navigation = document.querySelector('.navigation');
+            if (!navigation) {
+                return;
+            }
+
+            const prevButton = navigation.querySelector('button:first-child');
+            const nextButton = navigation.querySelector('button:last-child');
+
+            if (prevButton) {
+                prevButton.disabled = currentSlide === 1;
+            }
+            if (nextButton) {
+                nextButton.disabled = currentSlide === totalSlides;
+            }
         }
         
         function previousSlide() {

--- a/sesion7.html
+++ b/sesion7.html
@@ -60,46 +60,6 @@
         }
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 10px;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        padding: 15px 20px;
-        border-radius: 50px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        border: none;
-        padding: 12px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 14px;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(118, 75, 162, 0.3);
-      }
-
-      .nav-button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
-      }
-
-      .nav-button:disabled {
-        background: #9ca3af;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 20px;
@@ -1028,13 +988,6 @@
       </div>
     </main>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
       let currentSlide = 1;
       const totalSlides = 4;
@@ -1067,15 +1020,20 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
+        const navigation = document.querySelector(".navigation");
+        if (!navigation) {
+          return;
+        }
 
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        const prevButton = navigation.querySelector("button:first-child");
+        const nextButton = navigation.querySelector("button:last-child");
+
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 1;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {

--- a/sesion8.html
+++ b/sesion8.html
@@ -60,46 +60,6 @@
         }
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 10px;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        padding: 15px 20px;
-        border-radius: 50px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        border: none;
-        padding: 12px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 14px;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(118, 75, 162, 0.3);
-      }
-
-      .nav-button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
-      }
-
-      .nav-button:disabled {
-        background: #9ca3af;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 20px;
@@ -908,12 +868,6 @@
     </main>
 
     <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
       let currentSlide = 1;
       const totalSlides = 4;
@@ -948,15 +902,20 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
+        const navigation = document.querySelector(".navigation");
+        if (!navigation) {
+          return;
+        }
 
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        const prevButton = navigation.querySelector("button:first-child");
+        const nextButton = navigation.querySelector("button:last-child");
+
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 1;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {

--- a/sesion9.html
+++ b/sesion9.html
@@ -60,46 +60,6 @@
         }
       }
 
-      .navigation {
-        position: fixed;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        gap: 10px;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        padding: 15px 20px;
-        border-radius: 50px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
-      .nav-button {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        border: none;
-        padding: 12px 20px;
-        border-radius: 25px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 14px;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(118, 75, 162, 0.3);
-      }
-
-      .nav-button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(118, 75, 162, 0.4);
-      }
-
-      .nav-button:disabled {
-        background: #9ca3af;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-      }
-
       .slide-counter {
         position: fixed;
         top: 20px;
@@ -902,13 +862,6 @@
       </div>
     </main>
 
-    <!-- Navigation -->
-    <div class="navigation" hidden>
-      <button class="nav-button" onclick="previousSlide()">⬅️ Anterior</button>
-      <button class="nav-button" onclick="resetAll()">🔄 Reiniciar</button>
-      <button class="nav-button" onclick="nextSlide()">Siguiente ➡️</button>
-    </div>
-
     <script>
       let currentSlide = 1;
       const totalSlides = 4;
@@ -941,15 +894,20 @@
       }
 
       function updateNavigationButtons() {
-        const prevButton = document.querySelector(
-          ".navigation button:first-child"
-        );
-        const nextButton = document.querySelector(
-          ".navigation button:last-child"
-        );
+        const navigation = document.querySelector(".navigation");
+        if (!navigation) {
+          return;
+        }
 
-        prevButton.disabled = currentSlide === 1;
-        nextButton.disabled = currentSlide === totalSlides;
+        const prevButton = navigation.querySelector("button:first-child");
+        const nextButton = navigation.querySelector("button:last-child");
+
+        if (prevButton) {
+          prevButton.disabled = currentSlide === 1;
+        }
+        if (nextButton) {
+          nextButton.disabled = currentSlide === totalSlides;
+        }
       }
 
       function previousSlide() {


### PR DESCRIPTION
## Summary
- remove the hidden slide navigation containers and styling from the session pages so only the shared layout controls remain
- update every slide script to bail out gracefully when no local navigation element exists
- clean up responsive overrides that referenced the removed navigation block

## Testing
- not run (static HTML updates)


------
https://chatgpt.com/codex/tasks/task_e_68d0bc632ee8832582e387694ab62124