### PR TITLE
Evita duplicar la carga de layout desde nav-inject

### DIFF
--- a/js/nav-inject.js
+++ b/js/nav-inject.js
@@ -27,6 +27,14 @@
 
   if (document.querySelector("script[data-qs='layout-loader']")) return;
 
+  const hasLayoutScript = Array.from(document.querySelectorAll("script[src]"))
+    .filter((script) => script !== currentScript)
+    .some((script) => {
+      const src = script.getAttribute("src") || "";
+      return /(?:^|\/|\\)layout\.js(?:$|[?#])/.test(src);
+    });
+  if (hasLayoutScript) return;
+
   const loader = document.createElement("script");
   loader.defer = true;
   loader.src = layoutSrc;


### PR DESCRIPTION
## Summary
- evita que nav-inject inserte un segundo script de layout.js cuando la página ya lo incluyó explícitamente

## Testing
- no tests were run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d0c50157e483258ce6b82838ca587b