### PR TITLE
Fix forum reaction handler import

### DIFF
--- a/js/forum-init.js
+++ b/js/forum-init.js
@@ -472,7 +472,7 @@ function createReplyElement(reply, depth = 0){
       btnReact.dataset.loading = '1';
       btnReact.classList.add('opacity-50');
       try {
-        await reactToForumReply(currentTopicId, reply.id, 'like');
+        await registerForumReplyReaction(currentTopicId, reply.id, 'like');
       } catch (err) {
         alert(err?.message || err || 'No fue posible registrar tu reacción');
       } finally {


### PR DESCRIPTION
## Summary
- replace the obsolete reactToForumReply call with registerForumReplyReaction in the forum UI
- ensure the reaction button uses the function that is actually exported by firebase.js

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d18af6d3a88325866002066bd6a494