### PR TITLE
Fix duplicate buildReplyTree declaration

### DIFF
--- a/js/forum-init.js
+++ b/js/forum-init.js
@@ -78,7 +78,7 @@ function renderSignedOutState(){
   topicsList.appendChild(div);
 }
 
-function buildReplyTree(items = []){
+function buildRepliesTree(items = []){
   const map = new Map();
   const roots = [];
   items.forEach(item => {
@@ -323,7 +323,7 @@ function renderReplies(items = []){
     responsesList.appendChild(empty);
     return;
   }
-  const tree = buildReplyTree(items);
+  const tree = buildRepliesTree(items);
   tree.forEach(reply => {
     responsesList.appendChild(createReplyElement(reply, 0));
   });


### PR DESCRIPTION
## Summary
- rename the reply tree helper function to `buildRepliesTree` to avoid name collisions
- update the reply rendering logic to call the renamed helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d18ff588f08325be03c718432bfbca