### PR TITLE
Create floating notification center

### DIFF
--- a/index.html
+++ b/index.html
@@ -1006,6 +1006,618 @@
         border-left-color: #fbbf24;
       }
 
+
+      .realtime-center {
+        position: fixed;
+        top: clamp(16px, 3vw, 32px);
+        right: clamp(16px, 3vw, 40px);
+        z-index: 1200;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 12px;
+      }
+
+      .realtime-toggle {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 56px;
+        height: 56px;
+        border-radius: 999px;
+        border: 1px solid rgba(99, 102, 241, 0.32);
+        background: linear-gradient(135deg, rgba(99, 102, 241, 0.96), rgba(79, 70, 229, 0.96));
+        color: #ffffff;
+        font-size: 26px;
+        cursor: pointer;
+        box-shadow: 0 22px 45px rgba(15, 23, 42, 0.28);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .realtime-toggle:hover,
+      .realtime-toggle:focus-visible {
+        transform: translateY(-2px) scale(1.02);
+        box-shadow: 0 24px 52px rgba(79, 70, 229, 0.35);
+        outline: none;
+      }
+
+      .realtime-toggle.has-unread {
+        box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.28), 0 24px 52px rgba(79, 70, 229, 0.35);
+      }
+
+      .realtime-toggle__icon {
+        line-height: 1;
+        filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.25));
+      }
+
+      .realtime-toggle__badge {
+        position: absolute;
+        top: 6px;
+        right: 6px;
+        min-width: 20px;
+        height: 20px;
+        padding: 0 6px;
+        border-radius: 999px;
+        background: #f97316;
+        color: #ffffff;
+        font-size: 0.7rem;
+        font-weight: 700;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: 0 6px 12px rgba(249, 115, 22, 0.35);
+      }
+
+      .realtime-panel {
+        width: min(480px, 94vw);
+        padding: clamp(18px, 3.6vw, 26px);
+        border-radius: var(--radius-lg);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        box-shadow: var(--shadow-card);
+        backdrop-filter: blur(16px);
+        display: grid;
+        gap: 14px;
+        opacity: 0;
+        transform: translateY(-12px) scale(0.98);
+        pointer-events: none;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+      }
+
+      .realtime-panel.is-open {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        pointer-events: auto;
+      }
+
+      .realtime-panel__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+      }
+
+      .realtime-panel__heading {
+        display: grid;
+        gap: 6px;
+        flex: 1;
+      }
+
+      .realtime-panel__eyebrow {
+        display: block;
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        font-weight: 600;
+        color: var(--accent-hover);
+      }
+
+      .realtime-panel__title-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .realtime-panel__title {
+        margin: 4px 0 0;
+        font-size: 1.22rem;
+        font-weight: 600;
+      }
+
+      .realtime-panel__close {
+        border: none;
+        background: rgba(99, 102, 241, 0.12);
+        color: var(--accent-hover);
+        width: 32px;
+        height: 32px;
+        border-radius: 999px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.1rem;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+
+      .realtime-panel__close:hover,
+      .realtime-panel__close:focus-visible {
+        background: rgba(99, 102, 241, 0.18);
+        transform: scale(1.05);
+        outline: none;
+      }
+
+      .realtime-panel__hint {
+        border-radius: var(--radius-md);
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        background: rgba(248, 250, 252, 0.85);
+        overflow: hidden;
+      }
+
+      .realtime-panel__hint[open] {
+        background: rgba(238, 242, 255, 0.92);
+        border-color: rgba(99, 102, 241, 0.24);
+      }
+
+      .realtime-panel__hint > summary {
+        list-style: none;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 9px 12px;
+        cursor: pointer;
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--accent-hover);
+      }
+
+      .realtime-panel__hint > summary:hover {
+        background: rgba(99, 102, 241, 0.08);
+      }
+
+      .realtime-panel__hint > summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .realtime-panel__hint > summary:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .realtime-panel__hint-icon {
+        font-size: 1rem;
+      }
+
+      .realtime-panel__hint-caret {
+        margin-left: auto;
+        width: 18px;
+        height: 18px;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(99, 102, 241, 0.12);
+        color: var(--accent-hover);
+        font-size: 0.72rem;
+        transition: transform 0.2s ease;
+      }
+
+      .realtime-panel__hint[open] .realtime-panel__hint-caret {
+        transform: rotate(90deg);
+      }
+
+      .realtime-panel__description {
+        margin: 0;
+        padding: 0 12px 12px;
+        color: var(--text-secondary);
+        font-size: 0.82rem;
+        line-height: 1.5;
+      }
+
+      .realtime-panel__status {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 0.78rem;
+        background: rgba(34, 197, 94, 0.12);
+        color: #047857;
+        box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.25);
+        width: fit-content;
+        margin-left: auto;
+        white-space: nowrap;
+      }
+
+      @media (max-width: 520px) {
+        .realtime-panel__status {
+          white-space: normal;
+        }
+      }
+
+      .realtime-panel__status::before {
+        content: "";
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #22c55e;
+        box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.18);
+      }
+
+      .realtime-panel__status[data-enabled="false"] {
+        background: rgba(148, 163, 184, 0.2);
+        color: var(--text-secondary);
+        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+      }
+
+      .realtime-panel__status[data-enabled="false"]::before {
+        background: rgba(148, 163, 184, 0.8);
+        box-shadow: none;
+      }
+
+      .realtime-panel__content {
+        display: grid;
+        gap: 16px;
+      }
+
+      @media (min-width: 560px) {
+        .realtime-panel__content {
+          grid-template-columns: minmax(0, 210px) minmax(0, 1fr);
+          align-items: start;
+        }
+      }
+
+      .realtime-panel__options {
+        display: grid;
+        gap: 12px;
+        align-self: stretch;
+      }
+
+      .realtime-panel__section-title {
+        margin: 0;
+        font-size: 0.9rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-hover);
+      }
+
+      .realtime-panel__note {
+        margin: 0;
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+      }
+
+      .realtime-notifications__list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 10px;
+        max-height: 220px;
+        overflow-y: auto;
+        padding-right: 4px;
+      }
+
+      .realtime-option {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 14px;
+        padding: 12px 14px;
+        border-radius: var(--radius-md);
+        background: rgba(248, 250, 252, 0.92);
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+      }
+
+      .realtime-option:hover,
+      .realtime-option:focus-within {
+        border-color: rgba(99, 102, 241, 0.35);
+        background: rgba(238, 242, 255, 0.9);
+        transform: translateY(-2px);
+      }
+
+      .realtime-option__leading {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .realtime-option__icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 14px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.3rem;
+        background: rgba(99, 102, 241, 0.16);
+        color: var(--accent-hover);
+      }
+
+      .realtime-option__content {
+        display: grid;
+        gap: 4px;
+      }
+
+      .realtime-option__title {
+        margin: 0;
+        font-weight: 600;
+        font-size: 0.96rem;
+      }
+
+      .realtime-option__description {
+        margin: 0;
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+      }
+
+      .realtime-option__switch {
+        position: relative;
+        width: 44px;
+        height: 24px;
+        border-radius: 999px;
+        background: rgba(148, 163, 184, 0.35);
+        border: none;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+
+      .realtime-option__switch::after {
+        content: "";
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: #ffffff;
+        box-shadow: 0 6px 14px rgba(15, 23, 42, 0.15);
+        transition: transform 0.2s ease;
+      }
+
+      .realtime-option__switch[aria-checked="true"] {
+        background: var(--accent);
+      }
+
+      .realtime-option__switch[aria-checked="true"]::after {
+        transform: translateX(20px);
+      }
+
+      .realtime-feed {
+        display: grid;
+        gap: 12px;
+        border-radius: var(--radius-md);
+        background: rgba(248, 250, 252, 0.92);
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        padding: 16px;
+        align-self: stretch;
+      }
+
+      .realtime-feed__header {
+        display: grid;
+        gap: 4px;
+      }
+
+      .realtime-feed__title {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+      }
+
+      .realtime-feed__description {
+        margin: 0;
+        font-size: 0.82rem;
+        color: var(--text-secondary);
+      }
+
+      .realtime-feed__empty {
+        display: grid;
+        gap: 4px;
+        align-items: center;
+        justify-items: start;
+        font-size: 0.86rem;
+        color: var(--text-secondary);
+        padding: 18px;
+        border-radius: var(--radius-md);
+        background: rgba(255, 255, 255, 0.8);
+        border: 1px dashed rgba(148, 163, 184, 0.4);
+      }
+
+      .realtime-feed__empty[hidden] {
+        display: none;
+      }
+
+      .realtime-feed__list {
+        display: grid;
+        gap: 12px;
+        max-height: 320px;
+        overflow-y: auto;
+        padding-right: 4px;
+      }
+
+      .realtime-feed__item {
+        display: grid;
+        gap: 8px;
+        padding: 14px;
+        border-radius: var(--radius-md);
+        background: #ffffff;
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        border-left: 4px solid var(--accent);
+        opacity: 0;
+        transform: translateY(6px);
+        transition: opacity 0.25s ease, transform 0.25s ease;
+      }
+
+      .realtime-feed__item.is-visible {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      .realtime-feed__item-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .realtime-feed__item-leading {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .realtime-feed__icon {
+        width: 42px;
+        height: 42px;
+        border-radius: 16px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.4rem;
+        background: rgba(99, 102, 241, 0.16);
+        color: var(--accent-hover);
+      }
+
+      .realtime-feed__item-info {
+        display: grid;
+        gap: 2px;
+      }
+
+      .realtime-feed__tag {
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        background: rgba(99, 102, 241, 0.16);
+        color: var(--accent-hover);
+        padding: 2px 8px;
+        border-radius: 999px;
+        width: fit-content;
+      }
+
+      .realtime-feed__meta {
+        font-size: 0.78rem;
+        color: var(--text-secondary);
+      }
+
+      .realtime-feed__message {
+        margin: 0;
+        color: var(--text-primary);
+        font-size: 0.92rem;
+      }
+
+      .realtime-feed__detail {
+        margin: 0;
+        font-size: 0.82rem;
+        color: var(--text-secondary);
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      @media (max-width: 720px) {
+        .realtime-center {
+          right: clamp(12px, 4vw, 20px);
+        }
+
+        .realtime-panel {
+          width: min(94vw, 440px);
+        }
+      }
+
+      .realtime-option[data-type="activity-received"] .realtime-option__icon,
+      .realtime-feed__item[data-type="activity-received"] .realtime-feed__icon {
+        background: rgba(37, 99, 235, 0.15);
+        color: #2563eb;
+      }
+
+      .realtime-feed__item[data-type="activity-received"] {
+        border-left-color: #2563eb;
+      }
+
+      .realtime-option[data-type="activity-graded"] .realtime-option__icon,
+      .realtime-feed__item[data-type="activity-graded"] .realtime-feed__icon {
+        background: rgba(124, 58, 237, 0.18);
+        color: #7c3aed;
+      }
+
+      .realtime-feed__item[data-type="activity-graded"] {
+        border-left-color: #7c3aed;
+      }
+
+      .realtime-option[data-type="homework"] .realtime-option__icon,
+      .realtime-feed__item[data-type="homework"] .realtime-feed__icon {
+        background: rgba(249, 115, 22, 0.16);
+        color: #f97316;
+      }
+
+      .realtime-feed__item[data-type="homework"] {
+        border-left-color: #f97316;
+      }
+
+      .realtime-option[data-type="evidence-student"] .realtime-option__icon,
+      .realtime-feed__item[data-type="evidence-student"] .realtime-feed__icon {
+        background: rgba(13, 148, 136, 0.16);
+        color: #0d9488;
+      }
+
+      .realtime-feed__item[data-type="evidence-student"] {
+        border-left-color: #0d9488;
+      }
+
+      .realtime-option[data-type="evidence-teacher"] .realtime-option__icon,
+      .realtime-feed__item[data-type="evidence-teacher"] .realtime-feed__icon {
+        background: rgba(79, 70, 229, 0.16);
+        color: #4f46e5;
+      }
+
+      .realtime-feed__item[data-type="evidence-teacher"] {
+        border-left-color: #4f46e5;
+      }
+
+      .realtime-option[data-type="forum-reply"] .realtime-option__icon,
+      .realtime-feed__item[data-type="forum-reply"] .realtime-feed__icon {
+        background: rgba(20, 184, 166, 0.16);
+        color: #14b8a6;
+      }
+
+      .realtime-feed__item[data-type="forum-reply"] {
+        border-left-color: #14b8a6;
+      }
+
+      .realtime-option[data-type="forum-reaction"] .realtime-option__icon,
+      .realtime-feed__item[data-type="forum-reaction"] .realtime-feed__icon {
+        background: rgba(250, 204, 21, 0.18);
+        color: #ca8a04;
+      }
+
+      .realtime-feed__item[data-type="forum-reaction"] {
+        border-left-color: #ca8a04;
+      }
+
+      .realtime-option[data-type="grades"] .realtime-option__icon,
+      .realtime-feed__item[data-type="grades"] .realtime-feed__icon {
+        background: rgba(34, 197, 94, 0.16);
+        color: #22c55e;
+      }
+
+      .realtime-feed__item[data-type="grades"] {
+        border-left-color: #22c55e;
+      }
+
       .footer {
         margin: 80px 0 32px;
         text-align: center;
@@ -1047,6 +1659,7 @@
         .hero-actions {
           justify-content: flex-start;
         }
+
       }
 
       @media (max-width: 640px) {
@@ -1059,6 +1672,11 @@
         .session-card,
         .student-uploads {
           padding: 26px 22px;
+        }
+
+        .realtime-panel {
+          width: min(96vw, 420px);
+          padding: 20px 18px;
         }
 
         .student-uploads__actions {
@@ -1074,6 +1692,19 @@
         .student-uploads__records-header {
           flex-direction: column;
           align-items: flex-start;
+        }
+
+        .realtime-option {
+          grid-template-columns: 1fr;
+          align-items: flex-start;
+        }
+
+        .realtime-option__switch {
+          justify-self: end;
+        }
+
+        .realtime-feed {
+          padding: 20px 18px;
         }
       }
     </style>
@@ -1199,6 +1830,76 @@
 
     </div>
 
+    <div class="realtime-center" data-realtime-center>
+      <button
+        class="realtime-toggle"
+        type="button"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="realtimePanel"
+        data-realtime-toggle
+      >
+        <span class="realtime-toggle__icon" aria-hidden="true">🔔</span>
+        <span class="sr-only" data-realtime-toggle-label>Abrir centro de notificaciones</span>
+        <span class="realtime-toggle__badge" data-realtime-badge hidden></span>
+      </button>
+
+      <section
+        class="realtime-panel"
+        id="realtimePanel"
+        role="dialog"
+        aria-label="Notificaciones en tiempo real"
+        tabindex="-1"
+        data-realtime-panel
+        hidden
+      >
+        <header class="realtime-panel__header">
+          <div class="realtime-panel__heading">
+            <span class="realtime-panel__eyebrow">Alertas inteligentes</span>
+            <div class="realtime-panel__title-row">
+              <h2 class="realtime-panel__title">Notificaciones en tiempo real</h2>
+              <span class="realtime-panel__status" data-realtime-status data-enabled="true" aria-live="polite">
+                Notificaciones en tiempo real activas.
+              </span>
+            </div>
+          </div>
+          <button type="button" class="realtime-panel__close" data-realtime-close aria-label="Cerrar notificaciones">
+            <span aria-hidden="true">×</span>
+            <span class="sr-only">Cerrar centro de notificaciones</span>
+          </button>
+        </header>
+        <details class="realtime-panel__hint">
+          <summary>
+            <span class="realtime-panel__hint-icon" aria-hidden="true">💡</span>
+            <span>¿Cómo funcionan las alertas?</span>
+            <span class="realtime-panel__hint-caret" aria-hidden="true">▸</span>
+          </summary>
+          <p class="realtime-panel__description">
+            Personaliza qué eventos generan avisos al instante y revisa el historial simulado de entregas, calificaciones y foro.
+          </p>
+        </details>
+        <div class="realtime-panel__content">
+          <div class="realtime-panel__options">
+            <h3 class="realtime-panel__section-title">Tipos de alerta</h3>
+            <ul class="realtime-notifications__list" data-realtime-options></ul>
+            <p class="realtime-panel__note">Tus preferencias se guardan en este dispositivo.</p>
+          </div>
+          <div class="realtime-feed">
+            <div class="realtime-feed__header">
+              <h3 class="realtime-feed__title">Actividad en vivo</h3>
+              <p class="realtime-feed__description">
+                Vista previa de cómo aparecerán las alertas en la plataforma.
+              </p>
+            </div>
+            <div class="realtime-feed__empty" data-realtime-empty>
+              <strong data-empty-title>Esperando actividad…</strong>
+              <span data-empty-message>Activa al menos un tipo para previsualizar las notificaciones en vivo.</span>
+            </div>
+            <div class="realtime-feed__list" data-realtime-feed></div>
+          </div>
+        </div>
+      </section>
+    </div>
 
 
     <!-- Contenido principal -->
@@ -1461,6 +2162,7 @@
 
         </section>
 
+
       </div>
 
     </main>
@@ -1598,6 +2300,7 @@
 
     </script>
 
+    <script type="module" src="js/realtime-notifications.js"></script>
     <script type="module" src="js/index-student-uploads.js"></script>
     <script defer src="js/back-home.js"></script>
 

--- a/js/realtime-notifications.js
+++ b/js/realtime-notifications.js
@@ -1,0 +1,513 @@
+const STORAGE_KEY = "qs:realtime-notifications";
+const BOOT_FLAG = "__qsRealtimeNotificationsBooted";
+let storageUnavailable = false;
+
+const OPTIONS = [
+  {
+    id: "activity-received",
+    icon: "📥",
+    label: "Recepción de actividades",
+    description:
+      "Confirma al instante cada vez que una actividad es entregada para alumnos y docentes.",
+  },
+  {
+    id: "activity-graded",
+    icon: "✅",
+    label: "Calificación de actividades",
+    description:
+      "Recibe un aviso cuando se publique la retroalimentación o la nota de una actividad.",
+  },
+  {
+    id: "homework",
+    icon: "📝",
+    label: "Tareas asignadas",
+    description: "Notificaciones inmediatas de nuevas tareas o cambios en sus fechas límite.",
+  },
+  {
+    id: "evidence-student",
+    icon: "📤",
+    label: "Evidencias del alumno",
+    description:
+      "Alertas cuando los estudiantes comparten archivos de evidencia o seguimiento.",
+  },
+  {
+    id: "evidence-teacher",
+    icon: "📚",
+    label: "Evidencias del docente",
+    description:
+      "Enterate cuando el equipo docente publique guías o ejemplos de evidencia.",
+  },
+  {
+    id: "forum-reply",
+    icon: "💬",
+    label: "Respuestas en el foro",
+    description:
+      "Sigue los comentarios nuevos en tus hilos y menciones dentro del foro colaborativo.",
+  },
+  {
+    id: "forum-reaction",
+    icon: "👏",
+    label: "Reacciones en el foro",
+    description: "Recibe un ping al instante cuando tus aportes reciban aplausos u otras reacciones.",
+  },
+  {
+    id: "grades",
+    icon: "📊",
+    label: "Actualizaciones de calificaciones",
+    description:
+      "Avisos globales cuando cambian promedios, parciales o calificaciones finales.",
+  },
+];
+
+const FEED_EVENTS = [
+  {
+    type: "activity-received",
+    icon: "📥",
+    message: "Camila R. envió la Actividad 04 “Plan de pruebas”.",
+    detail: "Alumno · Archivo PDF (1.2 MB).",
+  },
+  {
+    type: "activity-graded",
+    icon: "✅",
+    message: "Mtra. Salas calificó la Actividad 03 de Ana con 95.",
+    detail: "Incluye comentarios detallados para el cierre del sprint.",
+  },
+  {
+    type: "homework",
+    icon: "📝",
+    message: "Nueva tarea “Backlog de bugs críticos” asignada para la semana 6.",
+    detail: "El docente notificó a todo el grupo con la nueva rúbrica.",
+  },
+  {
+    type: "evidence-student",
+    icon: "📤",
+    message: "Kevin H. subió evidencia en video para la Sesión 8.",
+    detail: "Disponible en el repositorio compartido de la clase.",
+  },
+  {
+    type: "forum-reply",
+    icon: "💬",
+    message: "Mariana respondió en tu hilo “Integración continua”.",
+    detail: "Sugiere automatizar las pruebas de despliegue nocturno.",
+  },
+  {
+    type: "forum-reaction",
+    icon: "👏",
+    message: "Recibiste 3 aplausos en tu aporte sobre pipelines CI/CD.",
+    detail: "Participaron María, José y Andrea.",
+  },
+  {
+    type: "evidence-teacher",
+    icon: "📚",
+    message: "El equipo docente compartió nueva evidencia guía para Sprint 2.",
+    detail: "Incluye una rúbrica actualizada y ejemplos resueltos.",
+  },
+  {
+    type: "grades",
+    icon: "📊",
+    message: "Se actualizó la calificación global del Sprint 2 a 18/20.",
+    detail: "Promedio del grupo: 92%. Consulta detalles en Calificaciones.",
+  },
+  {
+    type: "activity-graded",
+    icon: "📝",
+    message: "Ing. Castro añadió retroalimentación a la Evidencia 05.",
+    detail: "Revisa los comentarios sobre el plan de pruebas automatizadas.",
+  },
+  {
+    type: "forum-reply",
+    icon: "🔔",
+    message: "Hay 3 nuevas respuestas en el tema “Pruebas exploratorias con Playwright”.",
+    detail: "Se sugirió cubrir escenarios móviles y de rendimiento.",
+  },
+  {
+    type: "homework",
+    icon: "⏱️",
+    message: "La tarea “Pruebas de carga” extendió su fecha límite al lunes 18:00 h.",
+    detail: "Aviso enviado a alumnos y docentes.",
+  },
+  {
+    type: "grades",
+    icon: "🎯",
+    message: "Tu promedio en QA Ágil se actualizó a 9.6.",
+    detail: "Última modificación registrada por Mtra. Rivera.",
+  },
+];
+
+function loadPreferences() {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return {};
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (error) {
+    storageUnavailable = true;
+    return {};
+  }
+}
+
+function persistPreferences(state) {
+  if (storageUnavailable || typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    storageUnavailable = true;
+  }
+}
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+function initRealtimeNotifications() {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  if (window[BOOT_FLAG]) return;
+  window[BOOT_FLAG] = true;
+
+  const doc = document;
+  const center = doc.querySelector("[data-realtime-center]");
+  if (!center) {
+    return;
+  }
+
+  const toggleButton = center.querySelector("[data-realtime-toggle]");
+  const panel = center.querySelector("[data-realtime-panel]");
+  const optionsList = center.querySelector("[data-realtime-options]");
+  const feedList = center.querySelector("[data-realtime-feed]");
+  const statusEl = center.querySelector("[data-realtime-status]");
+  const emptyEl = center.querySelector("[data-realtime-empty]");
+  const badgeEl = center.querySelector("[data-realtime-badge]");
+  const closeButton = center.querySelector("[data-realtime-close]");
+  const toggleLabel = center.querySelector("[data-realtime-toggle-label]");
+
+  if (!optionsList || !feedList || !toggleButton || !panel) {
+    return;
+  }
+
+  const emptyTitleEl = emptyEl?.querySelector("[data-empty-title]") || null;
+  const emptyMessageEl = emptyEl?.querySelector("[data-empty-message]") || null;
+
+  const stored = loadPreferences();
+  const state = {};
+  let shouldPersist = false;
+
+  OPTIONS.forEach((option) => {
+    const value = stored[option.id];
+    if (typeof value === "boolean") {
+      state[option.id] = value;
+    } else {
+      state[option.id] = true;
+      shouldPersist = true;
+    }
+  });
+
+  if (shouldPersist) {
+    persistPreferences(state);
+  }
+
+  const toggles = new Map();
+  const labelMap = new Map(OPTIONS.map((option) => [option.id, option.label]));
+  const timeFormatter = new Intl.DateTimeFormat("es-MX", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  let queue = [];
+  let timerId = null;
+  let unreadCount = 0;
+  let isPanelOpen = false;
+  let hideTimeoutId = null;
+
+  updateToggleLabel(false);
+  updateBadge();
+  toggleButton.setAttribute("aria-expanded", "false");
+
+  toggleButton.addEventListener("click", () => {
+    if (isPanelOpen) {
+      closePanel();
+    } else {
+      openPanel();
+    }
+  });
+
+  if (closeButton) {
+    closeButton.addEventListener("click", () => closePanel({ focusToggle: true }));
+  }
+
+  doc.addEventListener("pointerdown", (event) => {
+    if (!isPanelOpen) return;
+    const target = event.target;
+    if (target && typeof target === "object" && "nodeType" in target && center.contains(target)) {
+      return;
+    }
+    closePanel();
+  });
+
+  doc.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && isPanelOpen) {
+      event.preventDefault();
+      closePanel({ focusToggle: true });
+    }
+  });
+
+  renderOptions();
+  updateStatus();
+  filterFeedItems();
+  scheduleNextEvent();
+
+  function updateToggleLabel(open) {
+    const labelText = open ? "Cerrar centro de notificaciones" : "Abrir centro de notificaciones";
+    if (toggleLabel) {
+      toggleLabel.textContent = labelText;
+    }
+    toggleButton.setAttribute("aria-label", labelText);
+  }
+
+  function updateBadge() {
+    if (!badgeEl) return;
+    if (unreadCount > 0) {
+      badgeEl.hidden = false;
+      badgeEl.textContent = unreadCount > 9 ? "9+" : String(unreadCount);
+      toggleButton.classList.add("has-unread");
+    } else {
+      badgeEl.hidden = true;
+      badgeEl.textContent = "";
+      toggleButton.classList.remove("has-unread");
+    }
+  }
+
+  function openPanel() {
+    if (isPanelOpen) return;
+    if (hideTimeoutId) {
+      window.clearTimeout(hideTimeoutId);
+      hideTimeoutId = null;
+    }
+    panel.hidden = false;
+    requestAnimationFrame(() => {
+      panel.classList.add("is-open");
+    });
+    isPanelOpen = true;
+    toggleButton.setAttribute("aria-expanded", "true");
+    updateToggleLabel(true);
+    unreadCount = 0;
+    updateBadge();
+    if (typeof panel.focus === "function") {
+      panel.focus({ preventScroll: true });
+    }
+  }
+
+  function closePanel({ focusToggle = false } = {}) {
+    if (!isPanelOpen) return;
+    panel.classList.remove("is-open");
+    isPanelOpen = false;
+    toggleButton.setAttribute("aria-expanded", "false");
+    updateToggleLabel(false);
+    const handleTransitionEnd = () => {
+      if (!isPanelOpen) {
+        panel.hidden = true;
+      }
+    };
+    panel.addEventListener("transitionend", handleTransitionEnd, { once: true });
+    if (hideTimeoutId) {
+      window.clearTimeout(hideTimeoutId);
+    }
+    hideTimeoutId = window.setTimeout(() => {
+      if (!isPanelOpen) {
+        panel.hidden = true;
+      }
+    }, 220);
+    if (focusToggle) {
+      toggleButton.focus();
+    }
+  }
+
+  function renderOptions() {
+    optionsList.innerHTML = "";
+    OPTIONS.forEach((option) => {
+      const li = doc.createElement("li");
+      li.className = "realtime-option";
+      li.dataset.type = option.id;
+      li.innerHTML = `
+        <div class="realtime-option__leading">
+          <span class="realtime-option__icon" aria-hidden="true">${option.icon}</span>
+          <div class="realtime-option__content">
+            <span class="realtime-option__title">${option.label}</span>
+            <p class="realtime-option__description">${option.description}</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="realtime-option__switch"
+          role="switch"
+          aria-checked="${isEnabled(option.id) ? "true" : "false"}"
+          aria-label="Activar notificaciones de ${option.label}"
+          data-option-id="${option.id}"
+        ></button>
+      `;
+
+      const switchEl = li.querySelector(".realtime-option__switch");
+      if (switchEl) {
+        toggles.set(option.id, switchEl);
+        switchEl.addEventListener("click", () => {
+          setEnabled(option.id, !isEnabled(option.id));
+        });
+      }
+
+      optionsList.appendChild(li);
+    });
+  }
+
+  function isEnabled(id) {
+    return state[id] !== false;
+  }
+
+  function setEnabled(id, enabled) {
+    state[id] = enabled ? true : false;
+    const toggle = toggles.get(id);
+    if (toggle) {
+      toggle.setAttribute("aria-checked", enabled ? "true" : "false");
+    }
+    persistPreferences(state);
+    filterFeedItems();
+    updateStatus();
+  }
+
+  function getEnabledOptionIds() {
+    return OPTIONS.filter((option) => isEnabled(option.id)).map((option) => option.id);
+  }
+
+  function updateStatus() {
+    if (!statusEl) return;
+    const enabledCount = getEnabledOptionIds().length;
+    statusEl.setAttribute("data-enabled", enabledCount > 0 ? "true" : "false");
+    if (enabledCount > 0) {
+      statusEl.innerHTML = `
+        <span aria-hidden="true">🟢</span>
+        <span>Recibirás ${enabledCount} de ${OPTIONS.length} tipos en tiempo real.</span>
+      `;
+    } else {
+      statusEl.innerHTML = `
+        <span aria-hidden="true">⚪</span>
+        <span>Activa al menos un tipo para reanudar las alertas en tiempo real.</span>
+      `;
+    }
+  }
+
+  function updateEmptyState() {
+    if (!emptyEl) return;
+    const enabledCount = getEnabledOptionIds().length;
+    const visibleItems = feedList
+      ? Array.from(feedList.querySelectorAll(".realtime-feed__item")).filter((item) => !item.hidden).length
+      : 0;
+
+    if (enabledCount === 0) {
+      emptyEl.hidden = false;
+      if (emptyTitleEl) emptyTitleEl.textContent = "Notificaciones en pausa";
+      if (emptyMessageEl)
+        emptyMessageEl.textContent =
+          "Activa al menos un tipo para previsualizar las alertas en tiempo real.";
+      return;
+    }
+
+    if (visibleItems === 0) {
+      emptyEl.hidden = false;
+      if (emptyTitleEl) emptyTitleEl.textContent = "Esperando actividad…";
+      if (emptyMessageEl)
+        emptyMessageEl.textContent =
+          "Las próximas entregas, calificaciones o movimientos del foro aparecerán aquí al instante.";
+      return;
+    }
+
+    emptyEl.hidden = true;
+  }
+
+  function filterFeedItems() {
+    const enabled = new Set(getEnabledOptionIds());
+    feedList.querySelectorAll(".realtime-feed__item").forEach((item) => {
+      const type = item.getAttribute("data-type");
+      const show = !type || enabled.has(type);
+      item.hidden = !show;
+    });
+    updateEmptyState();
+  }
+
+  function publishEvent(event) {
+    if (!event) return;
+    const card = doc.createElement("article");
+    card.className = "realtime-feed__item";
+    card.setAttribute("data-type", event.type);
+    const enabled = isEnabled(event.type);
+    card.hidden = !enabled;
+    const timeText = timeFormatter.format(new Date());
+    const detailHtml = event.detail ? `<p class="realtime-feed__detail">${event.detail}</p>` : "";
+    card.innerHTML = `
+      <div class="realtime-feed__item-header">
+        <div class="realtime-feed__item-leading">
+          <span class="realtime-feed__icon" aria-hidden="true">${event.icon || "🔔"}</span>
+          <div class="realtime-feed__item-info">
+            <span class="realtime-feed__tag">${labelMap.get(event.type) || "Notificación"}</span>
+            <span class="realtime-feed__meta">${timeText}</span>
+          </div>
+        </div>
+      </div>
+      <p class="realtime-feed__message">${event.message}</p>
+      ${detailHtml}
+    `;
+
+    feedList.prepend(card);
+
+    if (!isPanelOpen) {
+      unreadCount = Math.min(unreadCount + 1, 99);
+      updateBadge();
+    }
+
+    requestAnimationFrame(() => {
+      card.classList.add("is-visible");
+    });
+
+    while (feedList.children.length > 6) {
+      feedList.removeChild(feedList.lastElementChild);
+    }
+
+    updateEmptyState();
+  }
+
+  function nextDelay() {
+    const base = 4500;
+    const variance = Math.floor(Math.random() * 3500);
+    return base + variance;
+  }
+
+  function dequeueEvent() {
+    if (!queue.length) {
+      queue = shuffle(FEED_EVENTS.slice());
+    }
+    return queue.shift();
+  }
+
+  function scheduleNextEvent() {
+    clearTimeout(timerId);
+    timerId = window.setTimeout(() => {
+      const next = dequeueEvent();
+      publishEvent(next);
+      scheduleNextEvent();
+    }, nextDelay());
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initRealtimeNotifications, { once: true });
+} else {
+  initRealtimeNotifications();
+}
+
+export {}; // Garantiza que el archivo se trate como módulo.


### PR DESCRIPTION
## Summary
- replace the inline notification section with a bell icon that opens a floating panel containing the toggles and live feed
- update the real-time notifications module to drive the dropdown, unread badge and close interactions for the new panel
- compact the panel header, move the status badge next to the title and add a collapsible help hint so the live feed stays visible

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1935ba2788325b165480e4eae71b3