### PR TITLE
Reubica el centro de notificaciones para no interferir con el navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1009,11 +1009,11 @@
 
       .realtime-center {
         position: fixed;
-        top: clamp(16px, 3vw, 32px);
+        bottom: clamp(16px, 4vh, 40px);
         right: clamp(16px, 3vw, 40px);
         z-index: 1200;
         display: flex;
-        flex-direction: column;
+        flex-direction: column-reverse;
         align-items: flex-end;
         gap: 12px;
       }


### PR DESCRIPTION
## Summary
- mover el contenedor del centro de notificaciones a la esquina inferior derecha para liberar el espacio del navbar
- invertir la dirección del flex para que el panel se despliegue hacia arriba sobre el botón flotante

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1cdacd62883258074d3a021d2d47a