### PR TITLE
feat: agregar desplegable de entregas de actividades

### DIFF
--- a/calificaciones.html
+++ b/calificaciones.html
@@ -172,9 +172,245 @@
 
       }
 
-     #calificaciones-root .qsc-table td {
+      #calificaciones-root .qsc-table td {
         padding: 10px;
         border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+      }
+
+      #calificaciones-root .delivery-details {
+        border-radius: 16px;
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        overflow: hidden;
+      }
+
+      #calificaciones-root .delivery-summary {
+        list-style: none;
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 16px;
+        padding: 24px;
+        cursor: pointer;
+      }
+
+      #calificaciones-root .delivery-summary::-webkit-details-marker,
+      #calificaciones-root .delivery-summary::marker {
+        display: none;
+      }
+
+      #calificaciones-root .delivery-summary::after {
+        content: '';
+        width: 12px;
+        height: 12px;
+        border-right: 2px solid currentColor;
+        border-bottom: 2px solid currentColor;
+        transform: rotate(45deg);
+        transition: transform 0.2s ease;
+        margin-left: 8px;
+        align-self: center;
+      }
+
+      #calificaciones-root .delivery-details[open] .delivery-summary::after {
+        transform: rotate(-135deg);
+      }
+
+      #calificaciones-root .delivery-summary h3 {
+        margin: 0;
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: #111827;
+      }
+
+      #calificaciones-root .delivery-summary p {
+        margin: 4px 0 0;
+        color: #6b7280;
+        font-size: 0.875rem;
+      }
+
+      #calificaciones-root .delivery-summary-stats {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      #calificaciones-root .delivery-pill {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: center;
+        padding: 8px 12px;
+        border-radius: 12px;
+        background: #f3f4f6;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: #374151;
+        min-width: 96px;
+        line-height: 1.25;
+        gap: 2px;
+      }
+
+      #calificaciones-root .delivery-pill strong {
+        font-size: 1rem;
+        font-weight: 700;
+        text-transform: none;
+      }
+
+      #calificaciones-root .delivery-pill.pending {
+        background: rgba(251, 191, 36, 0.2);
+        color: #92400e;
+      }
+
+      #calificaciones-root .delivery-pill.done {
+        background: rgba(16, 185, 129, 0.2);
+        color: #065f46;
+      }
+
+      #calificaciones-root .delivery-pill.neutral {
+        background: rgba(59, 130, 246, 0.18);
+        color: #1d4ed8;
+      }
+
+      #calificaciones-root .delivery-panel {
+        border-top: 1px solid #e5e7eb;
+        padding: 20px 24px 24px;
+        background: #f9fafb;
+      }
+
+      #calificaciones-root .delivery-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      #calificaciones-root .delivery-empty {
+        text-align: center;
+        color: #6b7280;
+        font-size: 0.9rem;
+        padding: 16px 0;
+      }
+
+      #calificaciones-root .delivery-item {
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        padding: 16px;
+        background: #ffffff;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      #calificaciones-root .delivery-item--pending {
+        border-color: rgba(251, 191, 36, 0.45);
+        background: #fffbeb;
+      }
+
+      #calificaciones-root .delivery-item--done {
+        border-color: rgba(16, 185, 129, 0.45);
+        background: #f0fdf4;
+      }
+
+      #calificaciones-root .delivery-item-main {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      #calificaciones-root .delivery-item-title {
+        margin: 0;
+        font-weight: 600;
+        color: #111827;
+      }
+
+      #calificaciones-root .delivery-item-meta {
+        margin: 4px 0 0;
+        color: #6b7280;
+        font-size: 0.85rem;
+      }
+
+      #calificaciones-root .delivery-item-status {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 6px;
+        text-align: right;
+        font-size: 0.8rem;
+        color: #4b5563;
+      }
+
+      #calificaciones-root .delivery-item-status .delivery-pill {
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+        min-width: auto;
+        text-transform: none;
+        font-size: 0.75rem;
+        padding: 4px 10px;
+        border-radius: 999px;
+        background: rgba(107, 114, 128, 0.12);
+        color: #374151;
+      }
+
+      #calificaciones-root .delivery-item-status .delivery-pill.pending {
+        background: rgba(251, 191, 36, 0.25);
+        color: #92400e;
+      }
+
+      #calificaciones-root .delivery-item-status .delivery-pill.done {
+        background: rgba(16, 185, 129, 0.25);
+        color: #065f46;
+      }
+
+      #calificaciones-root .delivery-date {
+        font-size: 0.78rem;
+        color: #4b5563;
+      }
+
+      #calificaciones-root .delivery-item-extra {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        font-size: 0.85rem;
+        color: #4b5563;
+      }
+
+      #calificaciones-root .delivery-score {
+        font-weight: 600;
+        color: #1f2937;
+      }
+
+      #calificaciones-root .delivery-summary:focus,
+      #calificaciones-root .delivery-summary:focus-visible {
+        outline: 2px solid #3b82f6;
+        outline-offset: 3px;
+        border-radius: 12px;
+      }
+
+      @media (max-width: 640px) {
+        #calificaciones-root .delivery-summary {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        #calificaciones-root .delivery-summary::after {
+          margin-top: 8px;
+        }
+
+        #calificaciones-root .delivery-summary-stats {
+          justify-content: flex-start;
+        }
+
+        #calificaciones-root .delivery-item-status {
+          align-items: flex-start;
+          text-align: left;
+        }
       }
 
       #calificaciones-root .qsc-cell-main {
@@ -608,6 +844,33 @@
 
       </div>
 
+      <details class="delivery-details card-shadow mb-8" id="activityDeliveryDetails" open>
+        <summary class="delivery-summary">
+          <div>
+            <h3>Entrega de actividades</h3>
+            <p>Consulta de un vistazo tus próximas entregas, calificaciones registradas y el avance logrado.</p>
+          </div>
+          <div class="delivery-summary-stats">
+            <span class="delivery-pill pending" aria-live="polite">
+              Pendientes
+              <strong id="deliveryPendingCount">0</strong>
+            </span>
+            <span class="delivery-pill done" aria-live="polite">
+              Entregadas
+              <strong id="deliveryCompletedCount">0</strong>
+            </span>
+            <span class="delivery-pill neutral" aria-live="polite">
+              Avance
+              <strong id="deliveryCompletionPercent">0%</strong>
+            </span>
+          </div>
+        </summary>
+        <div class="delivery-panel">
+          <ul class="delivery-list" id="activityDeliveryList">
+            <li class="delivery-empty">Inicia sesión con tu cuenta institucional para ver el detalle de las actividades.</li>
+          </ul>
+        </div>
+      </details>
 
 
       <!-- Units Tabs -->

--- a/js/calificaciones-backend.js
+++ b/js/calificaciones-backend.js
@@ -286,6 +286,10 @@ function renderAlumno(items) {
   const kpiItems = $id('qsc-kpi-items');
   const kpiPond = $id('qsc-kpi-pond');
   const bar = $id('qsc-bar-fill');
+  const deliveryList = $id('activityDeliveryList');
+  const pendingCountEl = $id('deliveryPendingCount');
+  const completedCountEl = $id('deliveryCompletedCount');
+  const completionPctEl = $id('deliveryCompletionPercent');
 
   const stats = resumenGlobal(normalized);
   if (kpiTotal) kpiTotal.textContent = fmtPct(stats.porcentaje);
@@ -293,51 +297,155 @@ function renderAlumno(items) {
   if (kpiPond) kpiPond.textContent = fmtPct(stats.pondSum);
   if (bar) bar.style.width = stats.porcentaje.toFixed(2) + '%';
 
-  if (tbody) {
-    tbody.innerHTML = '';
-    if (!normalized.length) {
-      tbody.innerHTML = '<tr><td class="qsc-muted" colspan="10">Sin actividades registradas aun.</td></tr>';
-    } else {
-      for (let i = 0; i < normalized.length; i++) {
-        const it = normalized[i] || {};
-        const tipo = it.tipo || it.category || '-';
-        const uni = ((it.unidad !== undefined && it.unidad !== null) ? it.unidad : inferUnidad(it)) || '-';
-        const max = Number(it.displayMax) || 0;
-        const rawPts = Number(it.displayPuntos);
-        const hasDisplayPts = !Number.isNaN(rawPts);
-        const calificada = Boolean(it.estaCalificado);
-        const ptsText = calificada && hasDisplayPts ? rawPts.toFixed(2) : '-';
-        const pnd = Number(it.ponderacion) || 0;
-        const ratio = Number(it.normalizedRatio) || 0;
-        const aporta = ratio * pnd;
-        const escala = calificada && max > 0 ? escPct(100 * ratio) : '-';
-        const statusBadge = calificada
-          ? '<span class="qsc-status qsc-status--done">Calificada</span>'
-          : '<span class="qsc-status qsc-status--pending">Pendiente</span>';
-        let fecha = '-';
-        try {
-          const f = it.fecha;
-          if (f && typeof f.toDate === 'function') fecha = f.toDate().toLocaleDateString();
-          else if (f instanceof Date) fecha = f.toLocaleDateString();
-        } catch (_) {}
-        tbody.insertAdjacentHTML('beforeend', `
+  const deliveries = [];
+  let pendingCount = 0;
+  let completedCount = 0;
+  const tableRows = [];
+
+  if (!normalized.length) {
+    tableRows.push('<tr><td class="qsc-muted" colspan="10">Sin actividades registradas aun.</td></tr>');
+  } else {
+    for (let i = 0; i < normalized.length; i++) {
+      const it = normalized[i] || {};
+      const nombre = it.nombre || it.title || 'Actividad';
+      const tipo = it.tipo || it.category || '-';
+      const uni = ((it.unidad !== undefined && it.unidad !== null) ? it.unidad : inferUnidad(it)) || '-';
+      const max = Number(it.displayMax) || 0;
+      const maxText = max ? max.toFixed(2) : '-';
+      const rawPts = Number(it.displayPuntos);
+      const hasDisplayPts = !Number.isNaN(rawPts);
+      const calificada = Boolean(it.estaCalificado);
+      const ptsText = calificada && hasDisplayPts ? rawPts.toFixed(2) : '-';
+      const pnd = Number(it.ponderacion) || 0;
+      const ratio = Number(it.normalizedRatio) || 0;
+      const aporta = ratio * pnd;
+      const escala = calificada && max > 0 ? escPct(100 * ratio) : '-';
+      const statusBadge = calificada
+        ? '<span class="qsc-status qsc-status--done">Calificada</span>'
+        : '<span class="qsc-status qsc-status--pending">Pendiente</span>';
+      let fecha = '-';
+      let fechaValue = Number.NaN;
+      try {
+        const f = it.fecha;
+        if (f && typeof f.toDate === 'function') {
+          const date = f.toDate();
+          fecha = date.toLocaleDateString();
+          fechaValue = date.getTime();
+        } else if (f instanceof Date) {
+          fecha = f.toLocaleDateString();
+          fechaValue = f.getTime();
+        } else if (typeof f === 'string') {
+          const parsed = Date.parse(f);
+          if (!Number.isNaN(parsed)) {
+            const date = new Date(parsed);
+            fecha = date.toLocaleDateString();
+            fechaValue = parsed;
+          }
+        }
+      } catch (_) {}
+      tableRows.push(`
           <tr>
             <td>
               <div class="qsc-cell-main">
-                <span>${it.nombre || it.title || 'Actividad'}</span>
+                <span>${nombre}</span>
                 ${statusBadge}
               </div>
             </td>
             <td>${tipo}</td>
             <td>${uni}</td>
             <td style="text-align:right">${ptsText}</td>
-            <td style="text-align:right">${max ? max.toFixed(2) : '-'}</td>
+            <td style="text-align:right">${maxText}</td>
             <td style="text-align:right">${pnd}%</td>
             <td style="text-align:right">${fmtPct(aporta)}</td>
             <td style="text-align:center">${escala}</td>
             <td style="text-align:center">${fecha}</td>
           </tr>`);
+      if (calificada) completedCount++;
+      else pendingCount++;
+      deliveries.push({
+        nombre,
+        tipo,
+        unidad: uni,
+        ponderacion: pnd,
+        aporta,
+        calificada,
+        hasDisplayPts,
+        rawPoints: rawPts,
+        max,
+        escala,
+        fecha,
+        fechaValue,
+      });
+    }
+  }
+
+  if (tbody) {
+    tbody.innerHTML = tableRows.join('');
+  }
+
+  if (pendingCountEl) pendingCountEl.textContent = String(pendingCount);
+  if (completedCountEl) completedCountEl.textContent = String(completedCount);
+  const completionPct = normalized.length ? Math.round((completedCount / normalized.length) * 100) : 0;
+  if (completionPctEl) completionPctEl.textContent = completionPct + '%';
+
+  if (deliveryList) {
+    if (!normalized.length) {
+      deliveryList.innerHTML = '<li class="delivery-empty">Sin actividades registradas aun.</li>';
+    } else {
+      const sorted = deliveries.slice().sort((a, b) => {
+        if (a.calificada !== b.calificada) return a.calificada ? 1 : -1;
+        const timeA = Number.isFinite(a.fechaValue) ? a.fechaValue : Number.MAX_SAFE_INTEGER;
+        const timeB = Number.isFinite(b.fechaValue) ? b.fechaValue : Number.MAX_SAFE_INTEGER;
+        if (timeA !== timeB) return timeA - timeB;
+        const nameA = a.nombre || '';
+        const nameB = b.nombre || '';
+        return nameA.localeCompare(nameB, 'es', { sensitivity: 'base' });
+      });
+      const fragments = [];
+      for (let i = 0; i < sorted.length; i++) {
+        const item = sorted[i];
+        const metaParts = [];
+        if (item.tipo && item.tipo !== '-') metaParts.push(item.tipo);
+        if (item.unidad && item.unidad !== '-') metaParts.push('Unidad ' + item.unidad);
+        if (Number(item.ponderacion)) metaParts.push('Peso ' + fmtPct(item.ponderacion));
+        const meta = metaParts.join(' · ') || 'Sin detalles adicionales';
+        const statusClass = item.calificada ? 'done' : 'pending';
+        const statusText = item.calificada ? 'Entregada' : 'Pendiente';
+        const fechaLabel = item.fecha !== '-' ? item.fecha : 'Sin fecha registrada';
+        const maxDisplay = item.max > 0 ? item.max.toFixed(2) : '—';
+        let scoreText;
+        if (item.calificada && item.hasDisplayPts && Number.isFinite(item.rawPoints)) {
+          const maxValue = item.max > 0 ? item.max.toFixed(2) : '--';
+          scoreText = `${item.rawPoints.toFixed(2)} / ${maxValue} pts`;
+        } else if (item.max > 0) {
+          scoreText = `Máximo ${maxDisplay} pts`;
+        } else {
+          scoreText = 'Sin información de puntaje';
+        }
+        const extraSegments = [`<span class="delivery-score">${scoreText}</span>`];
+        if (Number(item.ponderacion)) extraSegments.push(`<span>Peso: ${fmtPct(item.ponderacion)}</span>`);
+        if (item.calificada && Number.isFinite(item.aporta) && item.aporta > 0.001) {
+          extraSegments.push(`<span>Aporta: ${fmtPct(item.aporta)}</span>`);
+        }
+        if (item.escala && item.escala !== '-') {
+          extraSegments.push(`<span>${item.calificada ? 'Escala' : 'Escala estimada'}: ${item.escala}</span>`);
+        }
+        fragments.push(`
+          <li class="delivery-item ${item.calificada ? 'delivery-item--done' : 'delivery-item--pending'}">
+            <div class="delivery-item-main">
+              <div>
+                <p class="delivery-item-title">${item.nombre}</p>
+                <p class="delivery-item-meta">${meta}</p>
+              </div>
+              <div class="delivery-item-status">
+                <span class="delivery-pill ${statusClass}">${statusText}</span>
+                <span class="delivery-date">Entrega: ${fechaLabel}</span>
+              </div>
+            </div>
+            <div class="delivery-item-extra">${extraSegments.join('')}</div>
+          </li>`);
       }
+      deliveryList.innerHTML = fragments.join('');
     }
   }
 


### PR DESCRIPTION
## Summary
- agregar tarjeta desplegable para consultar el estado de entregas de actividades
- integrar métricas de pendientes, entregadas y avance dentro del panel de alumno
- renderizar detalles de cada actividad reutilizando los datos normalizados de calificaciones

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1cf38c01c83258eb69533a3f9494f