### PR TITLE
Add session status controls across session pages

### DIFF
--- a/sesion1.html
+++ b/sesion1.html
@@ -282,6 +282,13 @@
               <h1 class="session-toolbar-title">Calidad de Software</h1>
             </div>
           </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion1">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion1" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
           <div
             class="slide-toolbar"
             role="tablist"

--- a/sesion10.html
+++ b/sesion10.html
@@ -193,6 +193,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion10">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion10" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div

--- a/sesion11.html
+++ b/sesion11.html
@@ -233,6 +233,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion11">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion11" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div

--- a/sesion12.html
+++ b/sesion12.html
@@ -245,6 +245,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion12">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion12" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div

--- a/sesion13.html
+++ b/sesion13.html
@@ -253,6 +253,14 @@
     </style>
   </head>
   <body class="flex items-center justify-center min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion13">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion13" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="kahoot-container">
       <!-- Floating Shapes -->
       <div class="floating-shapes">

--- a/sesion14.html
+++ b/sesion14.html
@@ -323,6 +323,14 @@
     </style>
   </head>
   <body class="flex items-center justify-center min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion14">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion14" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="exam-container">
       <!-- Floating Shapes -->
       <div class="floating-shapes">

--- a/sesion15.html
+++ b/sesion15.html
@@ -279,6 +279,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion15">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion15" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div

--- a/sesion16.html
+++ b/sesion16.html
@@ -410,6 +410,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion16">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion16" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div

--- a/sesion17.html
+++ b/sesion17.html
@@ -283,6 +283,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion17">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion17" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-wrapper">
       <div class="slide-container">
         <!-- Slide 1: Título -->

--- a/sesion18.html
+++ b/sesion18.html
@@ -296,6 +296,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion18">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion18" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-wrapper">
       <div class="slide-container">
         <!-- Slide 1: Título -->

--- a/sesion19.html
+++ b/sesion19.html
@@ -386,6 +386,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion19">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion19" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-wrapper">
       <div class="slide-container">
         <!-- Slide 1: Título -->

--- a/sesion2.html
+++ b/sesion2.html
@@ -330,6 +330,13 @@
               </p>␍␊
             </div>␍␊
           </div>␍␊
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion2">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion2" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
           <div␍␊
             class="slide-toolbar"␍␊
             role="tablist"␍␊

--- a/sesion20.html
+++ b/sesion20.html
@@ -413,6 +413,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion20">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion20" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-wrapper">
       <div class="slide-container">
         <!-- Slide 1: Título -->

--- a/sesion21.html
+++ b/sesion21.html
@@ -431,6 +431,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion21">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion21" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-container">
       <!-- Slide 1: Título -->
       <div class="slide active">

--- a/sesion22.html
+++ b/sesion22.html
@@ -398,6 +398,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion22">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion22" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-container">
       <!-- Slide 1: Título -->
       <div class="slide active">

--- a/sesion23.html
+++ b/sesion23.html
@@ -863,6 +863,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion23">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion23" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-container">
       <!-- Slide 1: Título -->
       <div class="slide active">

--- a/sesion24.html
+++ b/sesion24.html
@@ -935,6 +935,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion24">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion24" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-container">
       <!-- Slide 1: Título -->
       <div class="slide active">

--- a/sesion25.html
+++ b/sesion25.html
@@ -935,6 +935,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion25">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion25" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-container">
       <!-- Slide 1: Título -->
       <div class="slide active">

--- a/sesion26.html
+++ b/sesion26.html
@@ -250,6 +250,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion26">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion26" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion27.html
+++ b/sesion27.html
@@ -248,6 +248,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion27">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion27" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion28.html
+++ b/sesion28.html
@@ -391,6 +391,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion28">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion28" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion29.html
+++ b/sesion29.html
@@ -261,6 +261,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion29">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion29" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion3.html
+++ b/sesion3.html
@@ -664,6 +664,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion3">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion3" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="container">
       <!-- Slide Navigation -->
       <div class="slide-navigation">

--- a/sesion30.html
+++ b/sesion30.html
@@ -293,6 +293,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion30">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion30" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion31.html
+++ b/sesion31.html
@@ -313,6 +313,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion31">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion31" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion32.html
+++ b/sesion32.html
@@ -430,6 +430,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion32">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion32" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion33.html
+++ b/sesion33.html
@@ -287,6 +287,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion33">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion33" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion34.html
+++ b/sesion34.html
@@ -310,6 +310,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion34">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion34" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion35.html
+++ b/sesion35.html
@@ -114,6 +114,14 @@
     </style>
   </head>
   <body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion35">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion35" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Header -->
     <div class="bg-white shadow-lg">
       <div class="max-w-7xl mx-auto px-6 py-6">

--- a/sesion36.html
+++ b/sesion36.html
@@ -119,6 +119,14 @@
     </style>
   </head>
   <body class="bg-gradient-to-br from-blue-50 to-purple-100 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion36">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion36" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Header -->
     <div class="bg-white shadow-lg">
       <div class="max-w-7xl mx-auto px-6 py-6">

--- a/sesion37.html
+++ b/sesion37.html
@@ -467,6 +467,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion37">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion37" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-container">
       <!-- Slide 1: Título -->
       <div class="slide active">

--- a/sesion38.html
+++ b/sesion38.html
@@ -693,6 +693,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion38">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion38" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-container">
       <!-- Slide 1: Título -->
       <div class="slide active">

--- a/sesion39.html
+++ b/sesion39.html
@@ -713,6 +713,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion39">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion39" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="presentation-container">
       <!-- Slide 1: Título -->
       <div class="slide active">

--- a/sesion4.html
+++ b/sesion4.html
@@ -572,6 +572,14 @@
     </style>
   </head>
   <body>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion4">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion4" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <div class="container">
       <!-- Slide 1: Title -->
       <div id="slide1" class="slide">

--- a/sesion40.html
+++ b/sesion40.html
@@ -235,6 +235,14 @@
     </style>
   </head>
   <body class="bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion40">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion40" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <nav
       class="fixed top-0 left-0 right-0 bg-white/90 backdrop-blur-sm shadow-lg z-50"

--- a/sesion41.html
+++ b/sesion41.html
@@ -244,6 +244,14 @@
     </style>
   </head>
   <body class="bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion41">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion41" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <nav
       class="fixed top-0 left-0 right-0 bg-white/90 backdrop-blur-sm shadow-lg z-50"

--- a/sesion42.html
+++ b/sesion42.html
@@ -347,6 +347,14 @@
     </style>
   </head>
   <body class="bg-gradient-to-br from-indigo-50 via-blue-50 to-cyan-50">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion42">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion42" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <nav
       class="fixed top-0 left-0 right-0 bg-white/90 backdrop-blur-sm shadow-lg z-50"

--- a/sesion43.html
+++ b/sesion43.html
@@ -281,6 +281,14 @@
     </style>
   </head>
   <body class="bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-50">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion43">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion43" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <nav
       class="fixed top-0 left-0 right-0 bg-white/90 backdrop-blur-sm shadow-lg z-50"

--- a/sesion44.html
+++ b/sesion44.html
@@ -274,6 +274,14 @@
     </style>
   </head>
   <body class="bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-50">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion44">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion44" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <nav
       class="fixed top-0 left-0 right-0 bg-white/90 backdrop-blur-sm shadow-lg z-50"

--- a/sesion45.html
+++ b/sesion45.html
@@ -133,6 +133,14 @@
     </div>
 
     <main>
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion45">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion45" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <div class="badge">Sesión 45</div>
       <h1>Contenido en construcción</h1>
       <p>

--- a/sesion5.html
+++ b/sesion5.html
@@ -136,6 +136,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion5">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion5" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
         <!-- Slide 1: Título -->
         <div id="slide1" class="slide-transition fade-in">
             <div class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover">

--- a/sesion6.html
+++ b/sesion6.html
@@ -354,6 +354,14 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion6">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion6" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
     <!-- Navigation -->
     <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
       <div class="flex justify-between items-center max-w-6xl mx-auto">

--- a/sesion7.html
+++ b/sesion7.html
@@ -174,6 +174,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion7">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion7" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div

--- a/sesion8.html
+++ b/sesion8.html
@@ -177,6 +177,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion8">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion8" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div

--- a/sesion9.html
+++ b/sesion9.html
@@ -186,6 +186,14 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
+      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+        <span class="session-status-label" id="session-status-label-sesion9">Estado de la sesión</span>
+        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion9" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+          <span class="qs-session-status-dot" aria-hidden="true"></span>
+          <span class="qs-session-status-text">No realizada</span>
+        </button>
+      </div>
+
       <!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div


### PR DESCRIPTION
## Summary
- embed the session status control markup across every session HTML page so the state selector is visible everywhere
- update the shared layout bootstrap to detect and initialize existing status controls while keeping the UI synchronized via storage events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1eafda69483259dcffe6bcf1a5a7f