### PR TITLE
Add presentation activity and rebalance Unit 1 weights

### DIFF
--- a/calificaciones.html
+++ b/calificaciones.html
@@ -698,7 +698,7 @@
 
                 <p class="text-sm text-gray-600">
 
-                  Peso en unidad: 5% | Peso global: 1.5%
+                  Peso en unidad: 4% | Peso global: 1.2%
 
                 </p>
 
@@ -716,7 +716,7 @@
 
                 step="0.1"
 
-                data-weight="1.5"
+                data-weight="1.2"
 
                 placeholder="0.0"
 
@@ -740,7 +740,7 @@
 
                 <p class="text-sm text-gray-600">
 
-                  Peso en unidad: 5% | Peso global: 1.5%
+                  Peso en unidad: 4% | Peso global: 1.2%
 
                 </p>
 
@@ -758,7 +758,7 @@
 
                 step="0.1"
 
-                data-weight="1.5"
+                data-weight="1.2"
 
                 placeholder="0.0"
 
@@ -782,11 +782,11 @@
 
                 <p class="text-sm text-gray-600">
 
-                  <!-- Ajuste de ponderación: las asignaciones representan el 20 % de la unidad 1 en total,
+                  <!-- Ajuste de ponderación: las actividades prácticas principales ahora suman el 18 % de la unidad (5.4 % global),
 
-                       por lo que cada una aporta el 10 % de la unidad (equivalente al 3 % global) -->
+                       por lo que cada una aporta el 9 % de la unidad (equivalente al 2.7 % global) -->
 
-                  Peso en unidad: 10% | Peso global: 3%
+                  Peso en unidad: 9% | Peso global: 2.7%
 
                 </p>
 
@@ -804,7 +804,7 @@
 
                 step="0.1"
 
-                data-weight="3"
+                data-weight="2.7"
 
                 placeholder="0.0"
 
@@ -828,11 +828,11 @@
 
                 <p class="text-sm text-gray-600">
 
-                  <!-- Ajuste de ponderación: las asignaciones ahora representan un 20% de la unidad 1 en total,
+                  <!-- Ajuste de ponderación: las actividades prácticas principales ahora suman el 18 % de la unidad,
 
-                       por lo que cada una aporta el 10% del 20% global -->
+                       por lo que cada una aporta el 9 % de la unidad (equivalente al 2.7 % global) -->
 
-                  Peso en unidad: 10% | Peso global: 3%
+                  Peso en unidad: 9% | Peso global: 2.7%
 
                 </p>
 
@@ -850,7 +850,7 @@
 
                 step="0.1"
 
-              data-weight="3"
+              data-weight="2.7"
 
                 placeholder="0.0"
 
@@ -874,11 +874,11 @@
 
                 <p class="text-sm text-gray-600">
 
-                  <!-- Ajuste de ponderación: las actividades en clase suman el 25 % de la unidad 1.
+                  <!-- Ajuste de ponderación: las actividades en clase colaborativas suman el 14 % de la unidad 1.
 
-                       Esta actividad representa el 7.5 % de la unidad, equivalente al 2.25 % global -->
+                       Esta actividad representa el 7 % de la unidad, equivalente al 2.1 % global -->
 
-                  Peso en unidad: 7.5% | Peso global: 2.25%
+                  Peso en unidad: 7% | Peso global: 2.1%
 
                 </p>
 
@@ -896,7 +896,7 @@
 
                 step="0.1"
 
-                data-weight="2.25"
+                data-weight="2.1"
 
                 placeholder="0.0"
 
@@ -916,11 +916,11 @@
 
                 <p class="text-sm text-gray-600">
 
-                  <!-- Ajuste de ponderación: las actividades en clase suman el 25 % de la unidad 1.
+                  <!-- Ajuste de ponderación: las actividades en clase colaborativas suman el 14 % de la unidad 1.
 
-                       Esta actividad representa el 7.5 % de la unidad, equivalente al 2.25 % global -->
+                       Esta actividad representa el 7 % de la unidad, equivalente al 2.1 % global -->
 
-                  Peso en unidad: 7.5% | Peso global: 2.25%
+                  Peso en unidad: 7% | Peso global: 2.1%
 
                 </p>
 
@@ -938,7 +938,53 @@
 
                 step="0.1"
 
-                data-weight="2.25"
+                data-weight="2.1"
+
+                placeholder="0.0"
+
+              />
+
+            </div>
+
+            <div
+
+              class="grade-item flex items-center justify-between p-4 bg-gray-50 rounded-lg"
+
+            >
+
+              <div class="flex-1">
+
+                <h4 class="font-medium text-gray-800">
+
+                  Presentación de métricas (producto, proceso, proyecto)
+
+                </h4>
+
+                <p class="text-sm text-gray-600">
+
+                  <!-- Nueva actividad integradora centrada en el análisis de métricas claves.
+
+                       Representa el 10% de la unidad, equivalente al 3% global. -->
+
+                  Peso en unidad: 10% | Peso global: 3%
+
+                </p>
+
+              </div>
+
+              <input
+
+                type="number"
+
+                class="grade-input w-20 px-3 py-2 border border-gray-300 rounded-lg text-center"
+
+                min="0"
+
+                max="10"
+
+                step="0.1"
+
+                data-weight="3"
 
                 placeholder="0.0"
 
@@ -1004,11 +1050,11 @@
 
                 <p class="text-sm text-blue-600">
 
-                  <!-- El examen de la unidad 1 representa el 45 % de la unidad,
+                  <!-- El examen de la unidad 1 representa el 40 % de la unidad,
 
-                       equivalente al 13.5 % del total del curso -->
+                       equivalente al 12 % del total del curso -->
 
-                  Peso en unidad: 45% | Peso global: 13.5%
+                  Peso en unidad: 40% | Peso global: 12%
 
                 </p>
 
@@ -1026,7 +1072,7 @@
 
                 step="0.1"
 
-                data-weight="13.5"
+                data-weight="12"
 
                 placeholder="0.0"
 


### PR DESCRIPTION
## Summary
- adjust Unidad I activity weights to incorporate updated percentages and keep the global average aligned
- add the "Presentación de métricas (producto, proceso, proyecto)" activity with a 10% unit weight (3% global)
- update the Unit I exam weighting to 40% (12% global) for consistency with the new distribution

## Testing
- no automated tests were run (HTML content update)


------
https://chatgpt.com/codex/tasks/task_e_68d48ab76c20832592d9e26fd0c7e749