### PR TITLE
Adjust realtime center interactions on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1202,6 +1202,11 @@
         flex-direction: column-reverse;
         align-items: flex-end;
         gap: 12px;
+        pointer-events: none;
+      }
+
+      .realtime-center.is-panel-open {
+        pointer-events: auto;
       }
 
       .realtime-toggle {
@@ -1219,6 +1224,7 @@
         cursor: pointer;
         box-shadow: 0 22px 45px rgba(15, 23, 42, 0.28);
         transition: transform 0.2s ease, box-shadow 0.2s ease;
+        pointer-events: auto;
       }
 
       .realtime-toggle:hover,
@@ -1273,6 +1279,10 @@
         transform: translateY(-12px) scale(0.98);
         pointer-events: none;
         transition: opacity 0.2s ease, transform 0.2s ease;
+      }
+
+      .realtime-panel[hidden] {
+        display: none !important;
       }
 
       .realtime-panel.is-open {

--- a/js/realtime-notifications.js
+++ b/js/realtime-notifications.js
@@ -350,6 +350,7 @@ function initRealtimeNotifications() {
     panel.hidden = false;
     panel.style.removeProperty("display");
     panel.removeAttribute("aria-hidden");
+    center.classList.add("is-panel-open");
     requestAnimationFrame(() => {
       panel.classList.add("is-open");
     });
@@ -366,6 +367,7 @@ function initRealtimeNotifications() {
   function closePanel({ focusToggle = false } = {}) {
     if (!isPanelOpen) return;
     panel.classList.remove("is-open");
+    center.classList.remove("is-panel-open");
     isPanelOpen = false;
     toggleButton.setAttribute("aria-expanded", "false");
     updateToggleLabel(false);


### PR DESCRIPTION
## Summary
- prevent the realtime notification center wrapper from capturing pointer events when closed
- ensure the floating toggle remains clickable and the panel hides fully when marked hidden
- toggle a container class from JavaScript so the panel is interactive only while open

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4a873e4c8832596dfd6b8d715e8be