### PR TITLE
Corrige desplazamiento al cambiar de diapositiva

### DIFF
--- a/sesion1.html
+++ b/sesion1.html
@@ -1451,16 +1451,52 @@
         if (mainContent) {
           const behavior = prefersReducedMotion ? 'auto' : 'smooth';
           const rect = mainContent.getBoundingClientRect();
-          const offset =
-            (typeof window.scrollY === 'number' ? window.scrollY : window.pageYOffset || 0) +
-            rect.top;
+          const scrollTop =
+            typeof window.scrollY === 'number'
+              ? window.scrollY
+              : window.pageYOffset || 0;
+
+          const resolveAnchorOffset = () => {
+            let computedOffset = 0;
+            try {
+              const docEl = document.documentElement;
+              if (docEl && typeof window.getComputedStyle === 'function') {
+                const value = window
+                  .getComputedStyle(docEl)
+                  .getPropertyValue('--anchor-offset');
+                const parsed = parseFloat(value);
+                if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+                  computedOffset = Math.max(0, parsed);
+                }
+              }
+            } catch (_) {}
+
+            if (computedOffset) return computedOffset;
+
+            try {
+              const nav = document.querySelector('.qs-nav');
+              if (nav) {
+                const navRect = nav.getBoundingClientRect();
+                if (navRect && navRect.height) {
+                  computedOffset = Math.max(0, Math.round(navRect.height) + 12);
+                }
+              }
+            } catch (_) {}
+
+            return computedOffset;
+          };
+
+          const anchorOffset = resolveAnchorOffset();
+          const targetTop = Math.max(0, rect.top + scrollTop - anchorOffset);
 
           if (typeof window.scrollTo === 'function') {
             try {
-              window.scrollTo({ top: Math.max(0, offset), behavior });
+              window.scrollTo({ top: targetTop, behavior });
             } catch (_) {
-              window.scrollTo(0, Math.max(0, offset));
+              window.scrollTo(0, targetTop);
             }
+          } else {
+            window.scrollTo(0, targetTop);
           }
         }
 


### PR DESCRIPTION
## Summary
- ajusta el desplazamiento al cambiar de diapositiva en la Sesión 1 para considerar la altura de la barra de navegación

## Testing
- no se ejecutaron pruebas automatizadas (cambios en HTML/JS de comportamiento visual)


------
https://chatgpt.com/codex/tasks/task_e_68d4b2b3923483259f7086d47651bb27