### PR TITLE
Alinea la sesión 2 con la navegación mejorada

### DIFF
--- a/sesion2.html
+++ b/sesion2.html
@@ -162,174 +162,174 @@
         z-index: 0;
       }
 
-      .era-content {␍␊
-        position: relative;␍␊
-        z-index: 1;␍␊
-      }␍␊
-␍␊
-      .session-toolbar {␍␊
-        position: sticky;␍␊
-        top: calc(var(--nav-h, 72px) + 12px);␍␊
-        z-index: 40;␍␊
-        padding: 0.75rem 0;␍␊
-        margin-bottom: 1.75rem;␍␊
-      }␍␊
-␍␊
-      .session-toolbar-card {␍␊
-        display: flex;␍␊
-        align-items: center;␍␊
-        justify-content: space-between;␍␊
-        gap: 1.25rem;␍␊
-        padding: 1rem 1.5rem;␍␊
-        border-radius: 1.5rem;␍␊
-        background: rgba(255, 255, 255, 0.95);␍␊
-        border: 1px solid rgba(148, 163, 184, 0.18);␍␊
-        box-shadow: 0 18px 45px rgba(15, 23, 42, 0.1);␍␊
-        backdrop-filter: saturate(140%) blur(18px);␍␊
-      }␍␊
-␍␊
-      .session-toolbar-info {␍␊
-        display: flex;␍␊
-        align-items: center;␍␊
-        gap: 1rem;␍␊
-      }␍␊
-␍␊
-      .session-toolbar-badge {␍␊
-        width: 44px;␍␊
-        height: 44px;␍␊
-        border-radius: 14px;␍␊
-        background: linear-gradient(135deg, #4f46e5, #7c3aed);␍␊
-        color: #fff;␍␊
-        display: inline-flex;␍␊
-        align-items: center;␍␊
-        justify-content: center;␍␊
-        font-weight: 700;␍␊
-        font-size: 1.05rem;␍␊
-        box-shadow: 0 12px 25px rgba(79, 70, 229, 0.35);␍␊
-      }␍␊
-␍␊
-      .session-toolbar-kicker {␍␊
-        font-size: 0.75rem;␍␊
-        text-transform: uppercase;␍␊
-        letter-spacing: 0.08em;␍␊
-        color: #6366f1;␍␊
-        font-weight: 600;␍␊
-        margin-bottom: 0.15rem;␍␊
-      }␍␊
-␍␊
-      .session-toolbar-title {␍␊
-        font-size: 1.375rem;␍␊
-        font-weight: 700;␍␊
-        color: #1f2937;␍␊
-        margin: 0;␍␊
-      }␍␊
-␍␊
-      .slide-toolbar {␍␊
-        display: flex;␍␊
-        align-items: center;␍␊
-        gap: 0.5rem;␍␊
-        padding: 0.5rem;␍␊
-        border-radius: 9999px;␍␊
-        background: linear-gradient(␍␊
-          135deg,␍␊
-          rgba(99, 102, 241, 0.12),␍␊
-          rgba(129, 140, 248, 0.18)␍␊
-        );␍␊
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6),␍␊
-          0 8px 24px rgba(79, 70, 229, 0.18);␍␊
-        overflow-x: auto;␍␊
-        scroll-snap-type: x mandatory;␍␊
-        max-width: 100%;␍␊
-        -webkit-overflow-scrolling: touch;␍␊
-      }␍␊
-␍␊
-      .slide-toolbar::-webkit-scrollbar {␍␊
-        display: none;␍␊
-      }␍␊
-␍␊
-      .slide-tab {␍␊
-        position: relative;␍␊
-        display: inline-flex;␍␊
-        align-items: center;␍␊
-        justify-content: center;␍␊
-        gap: 0.4rem;␍␊
-        padding: 0.45rem 1.1rem;␍␊
-        border-radius: 9999px;␍␊
-        font-weight: 600;␍␊
-        font-size: 0.85rem;␍␊
-        color: #4338ca;␍␊
-        background: rgba(255, 255, 255, 0.82);␍␊
-        border: 1px solid rgba(99, 102, 241, 0.2);␍␊
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9),␍␊
-          0 1px 3px rgba(15, 23, 42, 0.08);␍␊
-        transition: transform 0.2s ease, box-shadow 0.2s ease,␍␊
-          color 0.2s ease, background 0.2s ease;␍␊
-        cursor: pointer;␍␊
-        scroll-snap-align: center;␍␊
-        white-space: nowrap;␍␊
-      }␍␊
-␍␊
-      .slide-tab:hover {␍␊
-        transform: translateY(-1px);␍␊
-        box-shadow: 0 12px 25px rgba(79, 70, 229, 0.25);␍␊
-        background: rgba(255, 255, 255, 0.95);␍␊
-      }␍␊
-␍␊
-      .slide-tab:focus-visible {␍␊
-        outline: 2px solid rgba(99, 102, 241, 0.6);␍␊
-        outline-offset: 3px;␍␊
-      }␍␊
-␍␊
-      .slide-tab-active {␍␊
-        color: #fff;␍␊
-        background: linear-gradient(135deg, #4f46e5, #7c3aed);␍␊
-        border-color: transparent;␍␊
-        box-shadow: 0 16px 30px rgba(79, 70, 229, 0.38);␍␊
-      }␍␊
-␍␊
-      .slide-tab-active::after {␍␊
-        content: "";␍␊
-        position: absolute;␍␊
-        left: 20%;␍␊
-        right: 20%;␍␊
-        bottom: -6px;␍␊
-        height: 4px;␍␊
-        border-radius: 9999px;␍␊
-        background: rgba(255, 255, 255, 0.75);␍␊
-      }␍␊
-␍␊
-      @media (max-width: 768px) {␍␊
-        .session-toolbar-card {␍␊
-          flex-direction: column;␍␊
-          align-items: flex-start;␍␊
-        }␍␊
-␍␊
-        .slide-toolbar {␍␊
-          width: 100%;␍␊
-        }␍␊
-      }␍␊
+      .era-content {
+        position: relative;
+        z-index: 1;
+      }
+
+      .session-toolbar {
+        position: sticky;
+        top: calc(var(--nav-h, 72px) + 12px);
+        z-index: 40;
+        padding: 0.75rem 0;
+        margin-bottom: 1.75rem;
+      }
+
+      .session-toolbar-card {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1.25rem;
+        padding: 1rem 1.5rem;
+        border-radius: 1.5rem;
+        background: rgba(255, 255, 255, 0.95);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 18px 45px rgba(15, 23, 42, 0.1);
+        backdrop-filter: saturate(140%) blur(18px);
+      }
+
+      .session-toolbar-info {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .session-toolbar-badge {
+        width: 44px;
+        height: 44px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #4f46e5, #7c3aed);
+        color: #fff;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        font-size: 1.05rem;
+        box-shadow: 0 12px 25px rgba(79, 70, 229, 0.35);
+      }
+
+      .session-toolbar-kicker {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #6366f1;
+        font-weight: 600;
+        margin-bottom: 0.15rem;
+      }
+
+      .session-toolbar-title {
+        font-size: 1.375rem;
+        font-weight: 700;
+        color: #1f2937;
+        margin: 0;
+      }
+
+      .slide-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem;
+        border-radius: 9999px;
+        background: linear-gradient(
+          135deg,
+          rgba(99, 102, 241, 0.12),
+          rgba(129, 140, 248, 0.18)
+        );
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6),
+          0 8px 24px rgba(79, 70, 229, 0.18);
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
+        max-width: 100%;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      .slide-toolbar::-webkit-scrollbar {
+        display: none;
+      }
+
+      .slide-tab {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.4rem;
+        padding: 0.45rem 1.1rem;
+        border-radius: 9999px;
+        font-weight: 600;
+        font-size: 0.85rem;
+        color: #4338ca;
+        background: rgba(255, 255, 255, 0.82);
+        border: 1px solid rgba(99, 102, 241, 0.2);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9),
+          0 1px 3px rgba(15, 23, 42, 0.08);
+        transition: transform 0.2s ease, box-shadow 0.2s ease,
+          color 0.2s ease, background 0.2s ease;
+        cursor: pointer;
+        scroll-snap-align: center;
+        white-space: nowrap;
+      }
+
+      .slide-tab:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 25px rgba(79, 70, 229, 0.25);
+        background: rgba(255, 255, 255, 0.95);
+      }
+
+      .slide-tab:focus-visible {
+        outline: 2px solid rgba(99, 102, 241, 0.6);
+        outline-offset: 3px;
+      }
+
+      .slide-tab-active {
+        color: #fff;
+        background: linear-gradient(135deg, #4f46e5, #7c3aed);
+        border-color: transparent;
+        box-shadow: 0 16px 30px rgba(79, 70, 229, 0.38);
+      }
+
+      .slide-tab-active::after {
+        content: "";
+        position: absolute;
+        left: 20%;
+        right: 20%;
+        bottom: -6px;
+        height: 4px;
+        border-radius: 9999px;
+        background: rgba(255, 255, 255, 0.75);
+      }
+
+      @media (max-width: 768px) {
+        .session-toolbar-card {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .slide-toolbar {
+          width: 100%;
+        }
+      }
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
-    <!-- Navigation -->␍␊
-    <nav␍␊
-      class="session-toolbar"␍␊
-      aria-label="Navegación de diapositivas de la sesión 2"␍␊
-    >␍␊
-      <div class="max-w-6xl mx-auto px-4">␍␊
-        <div class="session-toolbar-card">␍␊
-          <div class="session-toolbar-info">␍␊
-            <div class="session-toolbar-badge">QS</div>␍␊
-            <div>␍␊
-              <p class="session-toolbar-kicker">Sesión 2</p>␍␊
-              <h1 class="session-toolbar-title">␍␊
-                Conceptos Fundamentales de Calidad␍␊
-              </h1>␍␊
-              <p class="text-sm text-gray-500">␍␊
-                Marco teórico, evolución y aportes clave␍␊
-              </p>␍␊
-            </div>␍␊
-          </div>␍␊
+    <!-- Navigation -->
+    <nav
+      class="session-toolbar"
+      aria-label="Navegación de diapositivas de la sesión 2"
+    >
+      <div class="max-w-6xl mx-auto px-4">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">QS</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 2</p>
+              <h1 class="session-toolbar-title">
+                Conceptos Fundamentales de Calidad
+              </h1>
+              <p class="text-sm text-gray-500">
+                Marco teórico, evolución y aportes clave
+              </p>
+            </div>
+          </div>
           <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
             <span class="session-status-label" id="session-status-label-sesion2">Estado de la sesión</span>
             <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion2" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
@@ -337,87 +337,87 @@
               <span class="qs-session-status-text">No realizada</span>
             </button>
           </div>
-          <div␍␊
-            class="slide-toolbar"␍␊
-            role="tablist"␍␊
-            aria-label="Diapositivas de la sesión 2"␍␊
-          >␍␊
-            <button␍␊
-              type="button"␍␊
-              onclick="showSlide(1)"␍␊
-              class="slide-tab slide-tab-active"␍␊
-              id="slide1-btn"␍␊
-              role="tab"␍␊
-              aria-controls="slide1"␍␊
-              aria-selected="true"␍␊
-              tabindex="0"␍␊
-            >␍␊
-              Título␍␊
-            </button>␍␊
-            <button␍␊
-              type="button"␍␊
-              onclick="showSlide(2)"␍␊
-              class="slide-tab"␍␊
-              id="slide2-btn"␍␊
-              role="tab"␍␊
-              aria-controls="slide2"␍␊
-              aria-selected="false"␍␊
-              tabindex="-1"␍␊
-            >␍␊
-              La Fábula␍␊
-            </button>␍␊
-            <button␍␊
-              type="button"␍␊
-              onclick="showSlide(3)"␍␊
-              class="slide-tab"␍␊
-              id="slide3-btn"␍␊
-              role="tab"␍␊
-              aria-controls="slide3"␍␊
-              aria-selected="false"␍␊
-              tabindex="-1"␍␊
-            >␍␊
-              Discusión␍␊
-            </button>␍␊
-            <button␍␊
-              type="button"␍␊
-              onclick="showSlide(4)"␍␊
-              class="slide-tab"␍␊
-              id="slide4-btn"␍␊
-              role="tab"␍␊
-              aria-controls="slide4"␍␊
-              aria-selected="false"␍␊
-              tabindex="-1"␍␊
-            >␍␊
-              Evolución␍␊
-            </button>␍␊
-            <button␍␊
-              type="button"␍␊
-              onclick="showSlide(5)"␍␊
-              class="slide-tab"␍␊
-              id="slide5-btn"␍␊
-              role="tab"␍␊
-              aria-controls="slide5"␍␊
-              aria-selected="false"␍␊
-              tabindex="-1"␍␊
-            >␍␊
-              Gurús␍␊
-            </button>␍␊
-            <button␍␊
-              type="button"␍␊
-              onclick="showSlide(6)"␍␊
-              class="slide-tab"␍␊
-              id="slide6-btn"␍␊
-              role="tab"␍␊
-              aria-controls="slide6"␍␊
-              aria-selected="false"␍␊
-              tabindex="-1"␍␊
-            >␍␊
-              Trilogía␍␊
-            </button>␍␊
-          </div>␍␊
-        </div>␍␊
-      </div>␍␊
-    </nav>␍␊
+          <div
+            class="slide-toolbar"
+            role="tablist"
+            aria-label="Diapositivas de la sesión 2"
+          >
+            <button
+              type="button"
+              onclick="showSlide(1)"
+              class="slide-tab slide-tab-active"
+              id="slide1-btn"
+              role="tab"
+              aria-controls="slide1"
+              aria-selected="true"
+              tabindex="0"
+            >
+              Título
+            </button>
+            <button
+              type="button"
+              onclick="showSlide(2)"
+              class="slide-tab"
+              id="slide2-btn"
+              role="tab"
+              aria-controls="slide2"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              La Fábula
+            </button>
+            <button
+              type="button"
+              onclick="showSlide(3)"
+              class="slide-tab"
+              id="slide3-btn"
+              role="tab"
+              aria-controls="slide3"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Discusión
+            </button>
+            <button
+              type="button"
+              onclick="showSlide(4)"
+              class="slide-tab"
+              id="slide4-btn"
+              role="tab"
+              aria-controls="slide4"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Evolución
+            </button>
+            <button
+              type="button"
+              onclick="showSlide(5)"
+              class="slide-tab"
+              id="slide5-btn"
+              role="tab"
+              aria-controls="slide5"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Gurús
+            </button>
+            <button
+              type="button"
+              onclick="showSlide(6)"
+              class="slide-tab"
+              id="slide6-btn"
+              role="tab"
+              aria-controls="slide6"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Trilogía
+            </button>
+          </div>
+        </div>
+      </div>
+    </nav>
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8">
       <!-- Slide 1: Título -->
@@ -1432,89 +1432,246 @@
             </div>
           </div>
         </div>
-      </div>
+        </div>
     </main>
 
-    <script>␍␊
-      const slideButtons = Array.from(␍␊
-        document.querySelectorAll('.slide-toolbar [id$="-btn"]')␍␊
-      );␍␊
-      const totalSlides = slideButtons.length;␍␊
-      const prefersReducedMotion = (() => {␍␊
-        try {␍␊
-          return (␍␊
-            window.matchMedia &&␍␊
-            window.matchMedia('(prefers-reduced-motion: reduce)').matches␍␊
-          );␍␊
-        } catch (_) {␍␊
-          return false;␍␊
-        }␍␊
-      })();␍␊
-      let currentSlide = 1;␍␊
-␍␊
-      function showSlide(slideNumber) {␍␊
-        if (slideNumber < 1 || slideNumber > totalSlides) return;␍␊
-␍␊
-        slideButtons.forEach(function (button, index) {␍␊
-          const displayIndex = index + 1;␍␊
-          const slideElement = document.getElementById('slide' + displayIndex);␍␊
-          const isActive = displayIndex === slideNumber;␍␊
-␍␊
-          if (slideElement) {␍␊
-            slideElement.classList.toggle('hidden', !isActive);␍␊
-          }␍␊
-␍␊
-          button.classList.toggle('slide-tab-active', isActive);␍␊
-          button.setAttribute('aria-selected', isActive ? 'true' : 'false');␍␊
-          button.setAttribute('tabindex', isActive ? '0' : '-1');␍␊
-        });␍␊
-␍␊
-        const activeButton = document.getElementById(␍␊
-          'slide' + slideNumber + '-btn'␍␊
-        );␍␊
-␍␊
-        if (activeButton) {␍␊
-          const behavior = prefersReducedMotion ? 'auto' : 'smooth';␍␊
-          try {␍␊
-            requestAnimationFrame(function () {␍␊
-              activeButton.scrollIntoView({␍␊
-                behavior,␍␊
-                block: 'nearest',␍␊
-                inline: 'center',␍␊
-              });␍␊
-            });␍␊
-          } catch (_) {␍␊
-            if (!prefersReducedMotion) {␍␊
-              activeButton.scrollIntoView();␍␊
-            }␍␊
-          }␍␊
-        }␍␊
-␍␊
-        currentSlide = slideNumber;␍␊
-      }␍␊
-␍␊
-      // Keyboard navigation␍␊
-      document.addEventListener('keydown', function (e) {␍␊
-        if (e.key === 'ArrowLeft' && currentSlide > 1) {␍␊
-          showSlide(currentSlide - 1);␍␊
-        } else if (e.key === 'ArrowRight' && currentSlide < totalSlides) {␍␊
-          showSlide(currentSlide + 1);␍␊
-        }␍␊
-      });␍␊
-␍␊
-      if (totalSlides > 0) {␍␊
-        showSlide(1);␍␊
-      }␍␊
-    </script>␍␊
+    <div class="qs-slide-fab">
+      <button
+        type="button"
+        class="qs-slide-fab__btn is-prev"
+        data-slide-direction="prev"
+        aria-label="Diapositiva anterior"
+      >
+        <span aria-hidden="true">←</span>
+      </button>
+      <button
+        type="button"
+        class="qs-slide-fab__btn is-next"
+        data-slide-direction="next"
+        aria-label="Diapositiva siguiente"
+      >
+        <span aria-hidden="true">→</span>
+      </button>
+    </div>
+
+    <script>
+      const slideButtons = Array.from(
+        document.querySelectorAll('.slide-toolbar [id$="-btn"]')
+      );
+      const slides = Array.from(
+        document.querySelectorAll('main [id^="slide"]')
+      ).filter((element) => /^slide\d+$/i.test(element.id));
+
+      const mainContent = document.querySelector('main');
+
+      const fabButtons = Array.from(
+        document.querySelectorAll('.qs-slide-fab__btn')
+      );
+      const prevFab =
+        fabButtons.find((button) => button.dataset.slideDirection === 'prev') ||
+        null;
+      const nextFab =
+        fabButtons.find((button) => button.dataset.slideDirection === 'next') ||
+        null;
+      const totalSlides = Math.max(slides.length, slideButtons.length);
+      const prefersReducedMotion = (() => {
+        try {
+          return (
+            window.matchMedia &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches
+          );
+        } catch (_) {
+          return false;
+        }
+      })();
+      let currentSlide = 1;
+
+      function updateFabState() {
+        if (!prevFab && !nextFab) return;
+        const isSingleSlide = totalSlides <= 1;
+        const atStart = isSingleSlide || currentSlide <= 1;
+        const atEnd = isSingleSlide || currentSlide >= totalSlides;
+
+        if (prevFab) {
+          prevFab.disabled = atStart;
+          prevFab.classList.toggle('is-disabled', atStart);
+          if (atStart) {
+            prevFab.setAttribute('aria-disabled', 'true');
+          } else {
+            prevFab.removeAttribute('aria-disabled');
+          }
+        }
+
+        if (nextFab) {
+          nextFab.disabled = atEnd;
+          nextFab.classList.toggle('is-disabled', atEnd);
+          if (atEnd) {
+            nextFab.setAttribute('aria-disabled', 'true');
+          } else {
+            nextFab.removeAttribute('aria-disabled');
+          }
+        }
+      }
+
+      function showSlide(slideNumber) {
+        if (totalSlides === 0) {
+          updateFabState();
+          return;
+        }
+
+        const targetSlide = Math.min(Math.max(slideNumber, 1), totalSlides);
+
+        slides.forEach(function (slide, index) {
+          if (!slide) return;
+          const isActive = index + 1 === targetSlide;
+          slide.classList.toggle('hidden', !isActive);
+        });
+
+        slideButtons.forEach(function (button, index) {
+          const displayIndex = index + 1;
+          const isActive = displayIndex === targetSlide;
+          const slideElement = slides[index] ||
+            document.getElementById('slide' + displayIndex);
+
+          if (slideElement) {
+            slideElement.classList.toggle('hidden', !isActive);
+          }
+
+          button.classList.toggle('slide-tab-active', isActive);
+          button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+          button.setAttribute('tabindex', isActive ? '0' : '-1');
+        });
+
+        const activeButton = document.getElementById(
+          'slide' + targetSlide + '-btn'
+        );
+
+        if (activeButton) {
+          const behavior = prefersReducedMotion ? 'auto' : 'smooth';
+          try {
+            requestAnimationFrame(function () {
+              activeButton.scrollIntoView({
+                behavior,
+                block: 'nearest',
+                inline: 'center',
+              });
+            });
+          } catch (_) {
+            if (!prefersReducedMotion) {
+              activeButton.scrollIntoView();
+            }
+          }
+        }
+
+        currentSlide = targetSlide;
+        updateFabState();
 
 
+        if (mainContent) {
+          const behavior = prefersReducedMotion ? 'auto' : 'smooth';
+          const rect = mainContent.getBoundingClientRect();
+          const scrollTop =
+            typeof window.scrollY === 'number'
+              ? window.scrollY
+              : window.pageYOffset || 0;
 
+          const resolveAnchorOffset = () => {
+            let computedOffset = 0;
+            try {
+              const docEl = document.documentElement;
+              if (docEl && typeof window.getComputedStyle === 'function') {
+                const value = window
+                  .getComputedStyle(docEl)
+                  .getPropertyValue('--anchor-offset');
+                const parsed = parseFloat(value);
+                if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+                  computedOffset = Math.max(0, parsed);
+                }
+              }
+            } catch (_) {}
 
+            if (computedOffset) return computedOffset;
 
-  <script defer src="js/back-home.js"></script>
-  <script defer src="js/nav-inject.js"></script>
-  
-<script defer src="js/layout.js"></script>
-</body>
+            try {
+              const nav = document.querySelector('.qs-nav');
+              if (nav) {
+                const navRect = nav.getBoundingClientRect();
+                if (navRect && navRect.height) {
+                  computedOffset = Math.max(0, Math.round(navRect.height) + 12);
+                }
+              }
+            } catch (_) {}
+
+            return computedOffset;
+          };
+
+          const anchorOffset = resolveAnchorOffset();
+          const targetTop = Math.max(0, rect.top + scrollTop - anchorOffset);
+
+          if (typeof window.scrollTo === 'function') {
+            try {
+              window.scrollTo({ top: targetTop, behavior });
+            } catch (_) {
+              window.scrollTo(0, targetTop);
+            }
+          } else {
+            window.scrollTo(0, targetTop);
+          }
+        }
+
+      }
+
+      function nextSlide() {
+        if (totalSlides === 0) return;
+        showSlide(currentSlide + 1);
+      }
+
+      function previousSlide() {
+        if (totalSlides === 0) return;
+        showSlide(currentSlide - 1);
+      }
+
+      function goToSlide(slideNumber) {
+        showSlide(slideNumber);
+      }
+
+      // Keyboard navigation
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'ArrowLeft') {
+          previousSlide();
+        } else if (e.key === 'ArrowRight') {
+          nextSlide();
+        }
+      });
+
+      fabButtons.forEach(function (button) {
+        const direction = button.dataset.slideDirection;
+        if (direction === 'prev') {
+          button.addEventListener('click', function () {
+            previousSlide();
+          });
+        } else if (direction === 'next') {
+          button.addEventListener('click', function () {
+            nextSlide();
+          });
+        }
+      });
+
+      if (totalSlides > 0) {
+        showSlide(1);
+      } else {
+        updateFabState();
+      }
+
+      window.showSlide = showSlide;
+      window.nextSlide = nextSlide;
+      window.previousSlide = previousSlide;
+      window.goToSlide = goToSlide;
+    </script>
+
+    <script defer src="js/back-home.js"></script>
+    <script defer src="js/nav-inject.js"></script>
+    <script defer src="js/layout.js"></script>
+  </body>
 </html>
 


### PR DESCRIPTION
## Summary
- normalicé los estilos y el marcado de la barra de herramientas de la sesión 2 para eliminar caracteres de control y dejar la estructura limpia
- añadí el contenedor `qs-slide-fab` y reemplacé el script de navegación por la versión avanzada utilizada en la sesión 1

## Testing
- no se realizaron pruebas (no solicitadas)

------
https://chatgpt.com/codex/tasks/task_e_68d4b4bf56148325b9dd4ec24a8817ea