### PR TITLE
Refactor sesión 2 toolbar layout

### DIFF
--- a/sesion2.html
+++ b/sesion2.html
@@ -171,141 +171,50 @@
         position: sticky;
         top: calc(var(--nav-h, 72px) + 12px);
         z-index: 40;
-        padding: 0.75rem 0;
-        margin-bottom: 1.75rem;
+        padding: 0.5rem 0;
+        margin-bottom: 1.25rem;
       }
 
-      .session-toolbar-card {
+      .session-toolbar-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 1.25rem;
-        padding: 1rem 1.5rem;
-        border-radius: 1.5rem;
-        background: rgba(255, 255, 255, 0.95);
-        border: 1px solid rgba(148, 163, 184, 0.18);
-        box-shadow: 0 18px 45px rgba(15, 23, 42, 0.1);
-        backdrop-filter: saturate(140%) blur(18px);
-      }
-
-      .session-toolbar-info {
-        display: flex;
-        align-items: center;
         gap: 1rem;
+        padding: 0.75rem 1.25rem;
+        border-radius: 1rem;
+        background: rgba(255, 255, 255, 0.94);
+        border: 1px solid rgba(148, 163, 184, 0.16);
+        box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+        backdrop-filter: saturate(130%) blur(12px);
       }
 
-      .session-toolbar-badge {
-        width: 44px;
-        height: 44px;
-        border-radius: 14px;
-        background: linear-gradient(135deg, #4f46e5, #7c3aed);
-        color: #fff;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: 700;
-        font-size: 1.05rem;
-        box-shadow: 0 12px 25px rgba(79, 70, 229, 0.35);
+      .session-toolbar-titlegroup {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
       }
 
       .session-toolbar-kicker {
-        font-size: 0.75rem;
+        font-size: 0.7rem;
         text-transform: uppercase;
-        letter-spacing: 0.08em;
+        letter-spacing: 0.12em;
         color: #6366f1;
         font-weight: 600;
-        margin-bottom: 0.15rem;
       }
 
-      .session-toolbar-title {
-        font-size: 1.375rem;
+      .session-toolbar-heading {
+        font-size: 1.1rem;
         font-weight: 700;
         color: #1f2937;
         margin: 0;
-      }
-
-      .slide-toolbar {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.5rem;
-        border-radius: 9999px;
-        background: linear-gradient(
-          135deg,
-          rgba(99, 102, 241, 0.12),
-          rgba(129, 140, 248, 0.18)
-        );
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6),
-          0 8px 24px rgba(79, 70, 229, 0.18);
-        overflow-x: auto;
-        scroll-snap-type: x mandatory;
-        max-width: 100%;
-        -webkit-overflow-scrolling: touch;
-      }
-
-      .slide-toolbar::-webkit-scrollbar {
-        display: none;
-      }
-
-      .slide-tab {
-        position: relative;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.4rem;
-        padding: 0.45rem 1.1rem;
-        border-radius: 9999px;
-        font-weight: 600;
-        font-size: 0.85rem;
-        color: #4338ca;
-        background: rgba(255, 255, 255, 0.82);
-        border: 1px solid rgba(99, 102, 241, 0.2);
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9),
-          0 1px 3px rgba(15, 23, 42, 0.08);
-        transition: transform 0.2s ease, box-shadow 0.2s ease,
-          color 0.2s ease, background 0.2s ease;
-        cursor: pointer;
-        scroll-snap-align: center;
-        white-space: nowrap;
-      }
-
-      .slide-tab:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 12px 25px rgba(79, 70, 229, 0.25);
-        background: rgba(255, 255, 255, 0.95);
-      }
-
-      .slide-tab:focus-visible {
-        outline: 2px solid rgba(99, 102, 241, 0.6);
-        outline-offset: 3px;
-      }
-
-      .slide-tab-active {
-        color: #fff;
-        background: linear-gradient(135deg, #4f46e5, #7c3aed);
-        border-color: transparent;
-        box-shadow: 0 16px 30px rgba(79, 70, 229, 0.38);
-      }
-
-      .slide-tab-active::after {
-        content: "";
-        position: absolute;
-        left: 20%;
-        right: 20%;
-        bottom: -6px;
-        height: 4px;
-        border-radius: 9999px;
-        background: rgba(255, 255, 255, 0.75);
+        line-height: 1.3;
       }
 
       @media (max-width: 768px) {
-        .session-toolbar-card {
+        .session-toolbar-header {
           flex-direction: column;
           align-items: flex-start;
-        }
-
-        .slide-toolbar {
-          width: 100%;
+          gap: 0.75rem;
         }
       }
     </style>
@@ -317,102 +226,18 @@
       aria-label="Navegación de diapositivas de la sesión 2"
     >
       <div class="max-w-6xl mx-auto px-4">
-        <div class="session-toolbar-card">
-          <div class="session-toolbar-info">
-            <div class="session-toolbar-badge">QS</div>
-            <div>
-              <p class="session-toolbar-kicker">Sesión 2</p>
-              <h1 class="session-toolbar-title">
-                Conceptos Fundamentales de Calidad
-              </h1>
-              <p class="text-sm text-gray-500">
-                Marco teórico, evolución y aportes clave
-              </p>
-            </div>
+        <div class="session-toolbar-header">
+          <div class="session-toolbar-titlegroup">
+            <p class="session-toolbar-kicker">Sesión 2</p>
+            <h1 class="session-toolbar-heading">
+              Conceptos Fundamentales de Calidad
+            </h1>
           </div>
           <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
             <span class="session-status-label" id="session-status-label-sesion2">Estado de la sesión</span>
             <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion2" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
               <span class="qs-session-status-dot" aria-hidden="true"></span>
               <span class="qs-session-status-text">No realizada</span>
-            </button>
-          </div>
-          <div
-            class="slide-toolbar"
-            role="tablist"
-            aria-label="Diapositivas de la sesión 2"
-          >
-            <button
-              type="button"
-              onclick="showSlide(1)"
-              class="slide-tab slide-tab-active"
-              id="slide1-btn"
-              role="tab"
-              aria-controls="slide1"
-              aria-selected="true"
-              tabindex="0"
-            >
-              Título
-            </button>
-            <button
-              type="button"
-              onclick="showSlide(2)"
-              class="slide-tab"
-              id="slide2-btn"
-              role="tab"
-              aria-controls="slide2"
-              aria-selected="false"
-              tabindex="-1"
-            >
-              La Fábula
-            </button>
-            <button
-              type="button"
-              onclick="showSlide(3)"
-              class="slide-tab"
-              id="slide3-btn"
-              role="tab"
-              aria-controls="slide3"
-              aria-selected="false"
-              tabindex="-1"
-            >
-              Discusión
-            </button>
-            <button
-              type="button"
-              onclick="showSlide(4)"
-              class="slide-tab"
-              id="slide4-btn"
-              role="tab"
-              aria-controls="slide4"
-              aria-selected="false"
-              tabindex="-1"
-            >
-              Evolución
-            </button>
-            <button
-              type="button"
-              onclick="showSlide(5)"
-              class="slide-tab"
-              id="slide5-btn"
-              role="tab"
-              aria-controls="slide5"
-              aria-selected="false"
-              tabindex="-1"
-            >
-              Gurús
-            </button>
-            <button
-              type="button"
-              onclick="showSlide(6)"
-              class="slide-tab"
-              id="slide6-btn"
-              role="tab"
-              aria-controls="slide6"
-              aria-selected="false"
-              tabindex="-1"
-            >
-              Trilogía
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the sesión 2 toolbar card with a slimmer header that keeps the title and session status control
- remove the slide tab toolbar block and its associated styling from the navigation area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4b88e59b08325957af8bcc262c09c