### PR TITLE
Make session toolbars scroll with session content

### DIFF
--- a/sesion3.html
+++ b/sesion3.html
@@ -667,9 +667,6 @@
       }
 
       .session-toolbar {
-        position: sticky;
-        top: calc(var(--nav-h, 72px) + 16px);
-        z-index: 40;
         margin-bottom: 24px;
       }
 
@@ -839,84 +836,6 @@
             </button>
           </div>
         </div>
-        <nav
-          class="slide-toolbar"
-          role="tablist"
-          aria-label="Diapositivas de la sesión 3"
-        >
-          <button
-            type="button"
-            id="slide1-btn"
-            class="slide-tab slide-tab-active"
-            role="tab"
-            aria-selected="true"
-            aria-controls="slide1"
-            tabindex="0"
-            onclick="showSlide(1)"
-          >
-            1. Título
-          </button>
-          <button
-            type="button"
-            id="slide2-btn"
-            class="slide-tab"
-            role="tab"
-            aria-selected="false"
-            aria-controls="slide2"
-            tabindex="-1"
-            onclick="showSlide(2)"
-          >
-            2. Naturaleza del Software
-          </button>
-          <button
-            type="button"
-            id="slide3-btn"
-            class="slide-tab"
-            role="tab"
-            aria-selected="false"
-            aria-controls="slide3"
-            tabindex="-1"
-            onclick="showSlide(3)"
-          >
-            3. Calidad de Producto
-          </button>
-          <button
-            type="button"
-            id="slide4-btn"
-            class="slide-tab"
-            role="tab"
-            aria-selected="false"
-            aria-controls="slide4"
-            tabindex="-1"
-            onclick="showSlide(4)"
-          >
-            4. Calidad de Proceso
-          </button>
-          <button
-            type="button"
-            id="slide5-btn"
-            class="slide-tab"
-            role="tab"
-            aria-selected="false"
-            aria-controls="slide5"
-            tabindex="-1"
-            onclick="showSlide(5)"
-          >
-            5. Proceso → Producto
-          </button>
-          <button
-            type="button"
-            id="slide6-btn"
-            class="slide-tab"
-            role="tab"
-            aria-selected="false"
-            aria-controls="slide6"
-            tabindex="-1"
-            onclick="showSlide(6)"
-          >
-            6. Caso Ariane 5
-          </button>
-        </nav>
       </header>
       <!-- Slide 1: Title -->
       <div id="slide1" class="slide">

--- a/sesion4.html
+++ b/sesion4.html
@@ -575,9 +575,6 @@
       }
 
       .session-toolbar {
-        position: sticky;
-        top: calc(var(--nav-h, 72px) + 16px);
-        z-index: 40;
         margin-bottom: 24px;
       }
 
@@ -746,60 +743,6 @@
             </button>
           </div>
         </div>
-        <nav
-          class="slide-toolbar"
-          role="tablist"
-          aria-label="Diapositivas de la sesión 4"
-        >
-          <button
-            type="button"
-            id="slide1-btn"
-            class="slide-tab slide-tab-active"
-            role="tab"
-            aria-selected="true"
-            aria-controls="slide1"
-            tabindex="0"
-            onclick="showSlide(1)"
-          >
-            1. Introducción
-          </button>
-          <button
-            type="button"
-            id="slide2-btn"
-            class="slide-tab"
-            role="tab"
-            aria-selected="false"
-            aria-controls="slide2"
-            tabindex="-1"
-            onclick="showSlide(2)"
-          >
-            2. Jerarquía
-          </button>
-          <button
-            type="button"
-            id="slide3-btn"
-            class="slide-tab"
-            role="tab"
-            aria-selected="false"
-            aria-controls="slide3"
-            tabindex="-1"
-            onclick="showSlide(3)"
-          >
-            3. Modelo GQM
-          </button>
-          <button
-            type="button"
-            id="slide4-btn"
-            class="slide-tab"
-            role="tab"
-            aria-selected="false"
-            aria-controls="slide4"
-            tabindex="-1"
-            onclick="showSlide(4)"
-          >
-            4. Actividad
-          </button>
-        </nav>
       </header>
       <!-- Slide 1: Title -->
       <div id="slide1" class="slide">


### PR DESCRIPTION
## Summary
- remove the sticky positioning from the session toolbars in sessions 3 and 4 so they scroll away with the rest of the page content

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4c0e7cc2c8325b4f616c31a163936