### PR TITLE
Añade barra de sesión a sesiones posteriores

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -859,3 +859,145 @@ html:not(.role-teacher) .teacher-only {
     min-width: 520px;
   }
 }
+
+/* Shared session toolbar styling */
+.session-toolbar {
+  margin-bottom: clamp(18px, 4vw, 28px);
+}
+
+.session-toolbar-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  padding: clamp(0.85rem, 3vw, 1.25rem) clamp(1.1rem, 3.5vw, 1.75rem);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 20px 40px rgba(67, 56, 202, 0.15);
+  backdrop-filter: blur(14px) saturate(120%);
+}
+
+.session-toolbar-info {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.75rem, 2.5vw, 1.25rem);
+  color: #1a202c;
+}
+
+.session-toolbar-badge {
+  width: clamp(40px, 6vw, 48px);
+  height: clamp(40px, 6vw, 48px);
+  border-radius: 14px;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: clamp(0.9rem, 3vw, 1.1rem);
+  color: #fff;
+  box-shadow: 0 12px 25px rgba(118, 75, 162, 0.35);
+}
+
+.session-toolbar-kicker {
+  font-size: clamp(0.7rem, 2.4vw, 0.8rem);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #5a67d8;
+  font-weight: 600;
+  margin-bottom: 0.2rem;
+}
+
+.session-toolbar-title {
+  font-size: clamp(1.25rem, 4vw, 1.6rem);
+  font-weight: 700;
+  color: #1a202c;
+  margin: 0;
+}
+
+.session-toolbar-card .slide-toolbar {
+  order: 3;
+  width: 100%;
+}
+
+.slide-toolbar {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 10px 25px rgba(102, 126, 234, 0.2);
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+}
+
+.slide-toolbar::-webkit-scrollbar {
+  display: none;
+}
+
+.slide-tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1.1rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #3730a3;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), 0 6px 16px rgba(79, 70, 229, 0.15);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  white-space: nowrap;
+  scroll-snap-align: center;
+}
+
+.slide-tab:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.25);
+  background: rgba(255, 255, 255, 1);
+}
+
+.slide-tab:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.6);
+  outline-offset: 3px;
+}
+
+.slide-tab-active {
+  color: #fff;
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  border-color: transparent;
+  box-shadow: 0 16px 32px rgba(79, 70, 229, 0.35);
+}
+
+.slide-tab-active::after {
+  content: "";
+  position: absolute;
+  left: 20%;
+  right: 20%;
+  bottom: -6px;
+  height: 4px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+@media (max-width: 900px) {
+  .session-toolbar-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .session-status-control {
+    width: 100%;
+    margin-left: 0;
+    justify-content: space-between;
+  }
+
+  .slide-toolbar {
+    width: 100%;
+  }
+}

--- a/sesion10.html
+++ b/sesion10.html
@@ -193,15 +193,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion10">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion10" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 10">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">10</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 10</p>
+              <h1 class="session-toolbar-title">Introducción a V&V</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion10">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion10" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div
           class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover"

--- a/sesion11.html
+++ b/sesion11.html
@@ -233,15 +233,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion11">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion11" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 11">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">11</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 11</p>
+              <h1 class="session-toolbar-title">Estrategias de Pruebas (Testing)</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion11">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion11" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div
           class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover"

--- a/sesion12.html
+++ b/sesion12.html
@@ -245,15 +245,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion12">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion12" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 12">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">12</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 12</p>
+              <h1 class="session-toolbar-title">Pruebas de Seguridad</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion12">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion12" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div
           class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover"

--- a/sesion15.html
+++ b/sesion15.html
@@ -279,15 +279,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion15">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion15" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 15">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">15</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 15</p>
+              <h1 class="session-toolbar-title">Introducción a la Unidad II</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion15">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion15" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div
           class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover"

--- a/sesion16.html
+++ b/sesion16.html
@@ -410,15 +410,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion16">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion16" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 16">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">16</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 16</p>
+              <h1 class="session-toolbar-title">Origen y Estructura de CMMI</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion16">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion16" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div
           class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover"

--- a/sesion45.html
+++ b/sesion45.html
@@ -133,15 +133,26 @@
     </div>
 
     <main>
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion45">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion45" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 45">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">45</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 45</p>
+              <h1 class="session-toolbar-title">Contenido en construcción</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion45">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion45" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <div class="badge">Sesión 45</div>
+<div class="badge">Sesión 45</div>
       <h1>Contenido en construcción</h1>
       <p>
         Estamos preparando los recursos finales de la unidad. Mientras tanto, puedes volver a la

--- a/sesion5.html
+++ b/sesion5.html
@@ -136,15 +136,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion5">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion5" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 5">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">5</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 5</p>
+              <h1 class="session-toolbar-title">Tipos de Métricas (Producto)</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion5">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion5" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-        <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
         <div id="slide1" class="slide-transition fade-in">
             <div class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover">
                 <div class="max-w-4xl mx-auto">

--- a/sesion6.html
+++ b/sesion6.html
@@ -354,55 +354,44 @@
     </style>
   </head>
   <body class="bg-gray-50 min-h-screen">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion6">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion6" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
-
-    <!-- Navigation -->
-    <div class="fixed top-0 left-0 right-0 bg-white shadow-lg z-50 px-6 py-4">
-      <div class="flex justify-between items-center max-w-6xl mx-auto">
-        <div class="flex items-center space-x-4">
-          <h1 class="text-xl font-bold text-gray-800">
-            Sesión 6 - Métricas de Proceso y Proyecto
-          </h1>
-          <span
-            class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-medium"
-          >
-            Diapositiva <span id="currentSlide">1</span> de 5
-          </span>
+    <main class="max-w-6xl mx-auto px-4 pt-8 pb-24" role="main">
+      <header class="session-toolbar" aria-label="Navegación de la sesión 6">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">6</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 6</p>
+              <h1 class="session-toolbar-title">Midiendo la Fábrica: Métricas de Proceso y Proyecto</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion6">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion6" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
         </div>
-        <div class="flex space-x-2" hidden aria-hidden="true">
-          <button
-            onclick="previousSlide()"
-            id="prevBtn"
-            class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors"
-          >
-            ← Anterior
-          </button>
-          <button
-            onclick="nextSlide()"
-            id="nextBtn"
-            class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Siguiente →
-          </button>
+      </header>
+      <section class="session-slide-info bg-white/90 shadow-xl rounded-2xl px-6 py-4 flex flex-col gap-4 mb-8">
+        <div class="flex flex-wrap items-center justify-between gap-4">
+          <div class="flex items-center gap-4">
+            <h2 class="text-xl font-bold text-gray-800">Sesión 6 - Midiendo la Fábrica: Métricas de Proceso y Proyecto</h2>
+            <span class="bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-medium">
+              Diapositiva <span id="currentSlide">1</span> de 5
+            </span>
+          </div>
+          <div class="flex gap-2 flex-wrap" data-slide-nav>
+            <button onclick="previousSlide()" id="prevBtn" class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-lg transition-colors">← Anterior</button>
+            <button onclick="nextSlide()" id="nextBtn" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors">Siguiente →</button>
+          </div>
         </div>
-      </div>
-      <div class="w-full bg-gray-200 rounded-full h-2 mt-3">
-        <div
-          id="progressBar"
-          class="bg-blue-600 h-2 rounded-full transition-all duration-300"
-          style="width: 20%"
-        ></div>
-      </div>
-    </div>
-
-    <!-- Slides Container -->
-    <div class="pt-24 pb-8 px-6">
+        <div class="w-full bg-gray-200 rounded-full h-2">
+          <div id="progressBar" class="bg-blue-600 h-2 rounded-full transition-all duration-300" style="width: 20%"></div>
+        </div>
+      </section>
+      <!-- Slides Container -->
+      <div class="pt-8 pb-8 px-6">
       <div class="max-w-6xl mx-auto">
         <!-- Slide 1: Título -->
         <div class="slide active" id="slide1">
@@ -2214,10 +2203,7 @@ Copia este contenido y adáptalo a tu presentación.
         }
       }, 3000);
     </script>
-
-
-
-
+    </main>
 
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>

--- a/sesion7.html
+++ b/sesion7.html
@@ -174,15 +174,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion7">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion7" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 7">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">7</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 7</p>
+              <h1 class="session-toolbar-title">SQA vs QC - Dos Caras de la Misma Moneda</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion7">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion7" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div
           class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover"

--- a/sesion8.html
+++ b/sesion8.html
@@ -177,15 +177,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion8">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion8" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 8">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">8</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 8</p>
+              <h1 class="session-toolbar-title">El Plan de SQA</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion8">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion8" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div
           class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover"

--- a/sesion9.html
+++ b/sesion9.html
@@ -186,15 +186,26 @@
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 py-8 pb-32">
-      <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
-        <span class="session-status-label" id="session-status-label-sesion9">Estado de la sesión</span>
-        <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion9" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
-          <span class="qs-session-status-dot" aria-hidden="true"></span>
-          <span class="qs-session-status-text">No realizada</span>
-        </button>
-      </div>
+      <header class="session-toolbar" aria-label="Navegación de la sesión 9">
+        <div class="session-toolbar-card">
+          <div class="session-toolbar-info">
+            <div class="session-toolbar-badge">9</div>
+            <div>
+              <p class="session-toolbar-kicker">Sesión 9</p>
+              <h1 class="session-toolbar-title">Revisiones Técnicas Formales</h1>
+            </div>
+          </div>
+          <div class="session-status-control" data-role="session-status" role="group" aria-label="Estado de la sesión">
+            <span class="session-status-label" id="session-status-label-sesion9">Estado de la sesión</span>
+            <button type="button" class="qs-session-status-btn" data-role="session-status-toggle" aria-describedby="session-status-label-sesion9" data-state="not-started" aria-label="Estado de la sesión: No realizada. Activa para cambiar a En curso." title="Estado actual: No realizada. Haz clic para marcar como En curso.">
+              <span class="qs-session-status-dot" aria-hidden="true"></span>
+              <span class="qs-session-status-text">No realizada</span>
+            </button>
+          </div>
+        </div>
+      </header>
 
-      <!-- Slide 1: Título -->
+<!-- Slide 1: Título -->
       <div id="slide1" class="slide-transition fade-in">
         <div
           class="gradient-bg rounded-2xl p-12 text-white text-center mb-8 card-hover"


### PR DESCRIPTION
### Resumen
- Centralicé en `css/layout.css` los estilos compartidos para la barra de sesión y los controles de navegación.
- Integré la nueva barra de sesión con control de estado en las sesiones 5 a 12, 15, 16 y 45, actualizando los encabezados y sustituyendo los paneles antiguos.
- Reorganicé la cabecera de la sesión 6 para reutilizar la barra de sesión, manteniendo el contador y la barra de progreso.

### Pruebas
- No se ejecutaron pruebas automatizadas; los cambios afectan únicamente a contenido estático.


------
https://chatgpt.com/codex/tasks/task_e_68d4c34b11348325b98e3b45c6184868