### PR TITLE
Ajusta margen inferior del footer en index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1736,7 +1736,7 @@
       }
 
       .footer {
-        margin: 80px 0 32px;
+        margin: 80px 0 0;
         text-align: center;
         color: var(--text-secondary);
         font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- elimina el margen inferior heredado del footer en el index para evitar el hueco visible bajo el pie de página

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c957b01c8325b71357b18386d15d