### PR TITLE
Add assignment upload sections to grade items

### DIFF
--- a/calificaciones.html
+++ b/calificaciones.html
@@ -213,6 +213,109 @@
         background: rgba(251, 191, 36, 0.22);
       }
 
+      #calificaciones-root .grade-item {
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      #calificaciones-root .grade-actions {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.75rem;
+        min-width: 220px;
+      }
+
+      #calificaciones-root .grade-actions .grade-input,
+      #calificaciones-root .grade-actions .project-grade-input {
+        margin-bottom: 0.25rem;
+      }
+
+      #calificaciones-root .upload-control {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.35rem;
+        width: 100%;
+      }
+
+      #calificaciones-root .upload-control-buttons {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      #calificaciones-root .upload-trigger,
+      #calificaciones-root .upload-reset {
+        font-size: 0.8rem;
+        font-weight: 600;
+        padding: 0.45rem 0.8rem;
+        border-radius: 999px;
+        border: 1px solid rgba(79, 70, 229, 0.35);
+        background: rgba(99, 102, 241, 0.08);
+        color: #4338ca;
+        transition: all 0.2s ease;
+      }
+
+      #calificaciones-root .upload-trigger:hover,
+      #calificaciones-root .upload-reset:hover {
+        background: rgba(79, 70, 229, 0.18);
+      }
+
+      #calificaciones-root .upload-reset {
+        border-color: rgba(148, 163, 184, 0.45);
+        background: rgba(148, 163, 184, 0.12);
+        color: #334155;
+      }
+
+      #calificaciones-root .upload-reset:hover {
+        background: rgba(148, 163, 184, 0.2);
+      }
+
+      #calificaciones-root .upload-reset.upload-reset--hidden {
+        display: none;
+      }
+
+      #calificaciones-root .upload-status {
+        font-size: 0.75rem;
+        color: #4b5563;
+      }
+
+      #calificaciones-root .upload-status.upload-status--uploaded {
+        color: #047857;
+        font-weight: 600;
+      }
+
+      #calificaciones-root .upload-status.upload-status--uploaded::before {
+        content: "✔";
+        display: inline-block;
+        margin-right: 0.4rem;
+      }
+
+      @media (max-width: 640px) {
+        #calificaciones-root .grade-actions {
+          width: 100%;
+          align-items: stretch;
+        }
+
+        #calificaciones-root .upload-control,
+        #calificaciones-root .upload-control-buttons {
+          align-items: stretch;
+          justify-content: flex-start;
+        }
+
+        #calificaciones-root .upload-trigger,
+        #calificaciones-root .upload-reset {
+          width: 100%;
+          text-align: center;
+        }
+
+        #calificaciones-root .upload-status {
+          text-align: left;
+        }
+      }
+
 
       /* La vista de alumno permanece oculta para estudiantes, pero se muestra
 
@@ -2567,6 +2670,178 @@
 
 
     <script>
+
+      const UPLOAD_STORAGE_KEY = "qs-calificaciones-uploads";
+
+      function loadUploadState() {
+        if (typeof window === "undefined" || !window.localStorage) {
+          return {};
+        }
+        try {
+          const stored = window.localStorage.getItem(UPLOAD_STORAGE_KEY);
+          return stored ? JSON.parse(stored) : {};
+        } catch (error) {
+          console.warn(
+            "No fue posible cargar el historial de entregas desde el navegador.",
+            error
+          );
+          return {};
+        }
+      }
+
+      function saveUploadState(state) {
+        if (typeof window === "undefined" || !window.localStorage) {
+          return;
+        }
+        try {
+          window.localStorage.setItem(
+            UPLOAD_STORAGE_KEY,
+            JSON.stringify(state)
+          );
+        } catch (error) {
+          console.warn(
+            "No fue posible guardar el estado de entregas en el navegador.",
+            error
+          );
+        }
+      }
+
+      function initializeUploadControls() {
+        const gradeItems = document.querySelectorAll(
+          "#calificaciones-root .grade-item"
+        );
+        if (!gradeItems.length) {
+          return;
+        }
+
+        const state = loadUploadState();
+        const activeKeys = new Set();
+        const defaultStatus = "Sin archivo cargado";
+
+        gradeItems.forEach((item, index) => {
+          if (item.querySelector(".grade-actions")) {
+            return;
+          }
+
+          const gradeInput =
+            item.querySelector(".grade-input") ||
+            item.querySelector(".project-grade-input");
+          if (!gradeInput) {
+            return;
+          }
+
+          const titleEl = item.querySelector("h3, h4, h5, h6");
+          const activityTitle = titleEl
+            ? titleEl.textContent.trim()
+            : `Actividad ${index + 1}`;
+          const unitWrapper = item.closest(".unit-content");
+          const unitId = (unitWrapper && unitWrapper.id) || "general";
+          const activityKey = `${unitId}::${activityTitle}`;
+          activeKeys.add(activityKey);
+
+          const actions = document.createElement("div");
+          actions.className = "grade-actions";
+
+          const uploadWrapper = document.createElement("div");
+          uploadWrapper.className = "upload-control";
+
+          const fileInput = document.createElement("input");
+          const uploadId = `upload-${index}`;
+          fileInput.type = "file";
+          fileInput.id = uploadId;
+          fileInput.className = "upload-input";
+          fileInput.hidden = true;
+
+          const status = document.createElement("span");
+          status.className = "upload-status";
+          status.id = `upload-status-${index}`;
+          status.setAttribute("aria-live", "polite");
+          status.textContent = defaultStatus;
+
+          const buttonsWrapper = document.createElement("div");
+          buttonsWrapper.className = "upload-control-buttons";
+
+          const triggerButton = document.createElement("button");
+          triggerButton.type = "button";
+          triggerButton.className = "upload-trigger";
+          triggerButton.textContent = "Subir actividad";
+          triggerButton.setAttribute("aria-controls", uploadId);
+
+          const resetButton = document.createElement("button");
+          resetButton.type = "button";
+          resetButton.className = "upload-reset upload-reset--hidden";
+          resetButton.textContent = "Quitar archivo";
+          resetButton.setAttribute("aria-controls", uploadId);
+
+          function setUploadedState(fileName) {
+            status.textContent = `Archivo cargado: ${fileName}`;
+            status.title = fileName;
+            status.classList.add("upload-status--uploaded");
+            resetButton.classList.remove("upload-reset--hidden");
+          }
+
+          function setDefaultState() {
+            status.textContent = defaultStatus;
+            status.title = "";
+            status.classList.remove("upload-status--uploaded");
+            resetButton.classList.add("upload-reset--hidden");
+          }
+
+          const storedInfo = state[activityKey];
+          if (storedInfo && storedInfo.fileName) {
+            setUploadedState(storedInfo.fileName);
+          }
+
+          triggerButton.addEventListener("click", () => {
+            fileInput.click();
+          });
+
+          fileInput.addEventListener("change", () => {
+            const selected = fileInput.files && fileInput.files[0];
+            if (selected) {
+              setUploadedState(selected.name);
+              state[activityKey] = {
+                fileName: selected.name,
+                updatedAt: new Date().toISOString(),
+              };
+              saveUploadState(state);
+            } else {
+              delete state[activityKey];
+              saveUploadState(state);
+              setDefaultState();
+            }
+          });
+
+          resetButton.addEventListener("click", () => {
+            fileInput.value = "";
+            delete state[activityKey];
+            saveUploadState(state);
+            setDefaultState();
+          });
+
+          buttonsWrapper.appendChild(triggerButton);
+          buttonsWrapper.appendChild(resetButton);
+          uploadWrapper.appendChild(fileInput);
+          uploadWrapper.appendChild(buttonsWrapper);
+          uploadWrapper.appendChild(status);
+
+          gradeInput.setAttribute("aria-describedby", status.id);
+
+          actions.appendChild(gradeInput);
+          actions.appendChild(uploadWrapper);
+          item.appendChild(actions);
+        });
+
+        const staleKeys = Object.keys(state).filter(
+          (key) => !activeKeys.has(key)
+        );
+        if (staleKeys.length) {
+          staleKeys.forEach((key) => delete state[key]);
+          saveUploadState(state);
+        }
+      }
+
+      document.addEventListener("DOMContentLoaded", initializeUploadControls);
 
       // Student data
 


### PR DESCRIPTION
## Summary
- add upload controls with status and reset actions to each actividad in Calificaciones
- persist the nombre del archivo seleccionado en el almacenamiento local para mantener visibilidad tras recargar
- style the nuevos controles para que se integren con el diseño existente y funcionen en pantallas móviles

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d5736bf3188325b16b3c665c00965c