### PR TITLE
Add shared file viewer for uploaded materials

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -1001,3 +1001,118 @@ html:not(.role-teacher) .teacher-only {
     width: 100%;
   }
 }
+
+body.has-file-viewer {
+  overflow: hidden;
+}
+
+.file-viewer[hidden] {
+  display: none;
+}
+
+.file-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(20px, 6vw, 48px);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.file-viewer__backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  cursor: pointer;
+}
+
+.file-viewer__dialog {
+  position: relative;
+  width: min(960px, 96vw);
+  height: min(80vh, 720px);
+  display: flex;
+  flex-direction: column;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 28px 64px rgba(15, 23, 42, 0.35);
+  background: rgba(248, 250, 252, 0.98);
+  overflow: hidden;
+  outline: none;
+  z-index: 1;
+}
+
+.file-viewer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(16px, 3vw, 22px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(37, 99, 235, 0.12));
+}
+
+.file-viewer__title {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.2vw, 1.2rem);
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.file-viewer__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background var(--motion-duration, 0.2s) var(--motion-easing, ease),
+    color var(--motion-duration, 0.2s) var(--motion-easing, ease);
+}
+
+.file-viewer__close:hover,
+.file-viewer__close:focus-visible {
+  background: rgba(37, 99, 235, 0.18);
+  color: #1e3a8a;
+  outline: none;
+}
+
+.file-viewer__content {
+  flex: 1;
+  background: #ffffff;
+}
+
+.file-viewer__content iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #ffffff;
+}
+
+.file-viewer__notice {
+  margin: 0;
+  padding: clamp(12px, 3vw, 18px) clamp(16px, 3vw, 24px);
+  font-size: 0.95rem;
+  color: #475569;
+  background: rgba(148, 163, 184, 0.12);
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.file-viewer__notice a {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .file-viewer__dialog {
+    width: 100%;
+    height: 90vh;
+    border-radius: 18px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1117,6 +1117,39 @@
         gap: 10px;
       }
 
+      .student-uploads__item-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 18px;
+        border-radius: 999px;
+        border: 1px solid rgba(99, 102, 241, 0.45);
+        background: rgba(99, 102, 241, 0.12);
+        color: var(--accent);
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .student-uploads__item-button:hover,
+      .student-uploads__item-button:focus-visible {
+        background: rgba(79, 70, 229, 0.15);
+        transform: translateY(-2px);
+        box-shadow: 0 14px 24px rgba(99, 102, 241, 0.18);
+      }
+
+      .student-uploads__item-button:focus-visible {
+        outline: 2px solid rgba(99, 102, 241, 0.65);
+        outline-offset: 2px;
+      }
+
+      .student-uploads__item-button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+
       .student-uploads__item-link {
         display: inline-flex;
         align-items: center;
@@ -2334,6 +2367,27 @@
 
     </footer>
 
+    <div class="file-viewer" id="fileViewer" hidden aria-hidden="true">
+      <div class="file-viewer__backdrop" data-file-viewer-close></div>
+      <div class="file-viewer__dialog" role="dialog" aria-modal="true" aria-labelledby="fileViewerTitle">
+        <header class="file-viewer__header">
+          <h2 class="file-viewer__title" id="fileViewerTitle" data-file-viewer-title>Vista previa del archivo</h2>
+          <button type="button" class="file-viewer__close" aria-label="Cerrar vista previa" data-file-viewer-close>&times;</button>
+        </header>
+        <div class="file-viewer__content">
+          <iframe
+            data-file-viewer-frame
+            title="Vista previa del archivo seleccionado"
+            loading="lazy"
+            allow="fullscreen"
+          ></iframe>
+        </div>
+        <p class="file-viewer__notice">
+          Si el archivo no se muestra correctamente, puedes
+          <a data-file-viewer-download target="_blank" rel="noopener">abrirlo en una pestaña nueva</a>.
+        </p>
+      </div>
+    </div>
 
 
     <script>

--- a/js/file-viewer.js
+++ b/js/file-viewer.js
@@ -1,0 +1,117 @@
+const VIEWER_ID = "fileViewer";
+let viewerEl = null;
+let dialogEl = null;
+let titleEl = null;
+let frameEl = null;
+let fallbackLinkEl = null;
+let initialized = false;
+let lastActiveElement = null;
+
+function queryElements() {
+  if (viewerEl) return true;
+  viewerEl = document.getElementById(VIEWER_ID);
+  if (!viewerEl) return false;
+  dialogEl = viewerEl.querySelector(".file-viewer__dialog");
+  titleEl = viewerEl.querySelector("[data-file-viewer-title]");
+  frameEl = viewerEl.querySelector("[data-file-viewer-frame]");
+  fallbackLinkEl = viewerEl.querySelector("[data-file-viewer-download]");
+  if (dialogEl && !dialogEl.hasAttribute("tabindex")) {
+    dialogEl.setAttribute("tabindex", "-1");
+  }
+  return true;
+}
+
+function onKeyDown(event) {
+  if (!viewerEl || viewerEl.hidden) return;
+  if (event.key === "Escape") {
+    event.preventDefault();
+    closeFileViewer();
+  }
+}
+
+function onFocus(event) {
+  if (!viewerEl || viewerEl.hidden) return;
+  if (!dialogEl) return;
+  if (!dialogEl.contains(event.target)) {
+    dialogEl.focus({ preventScroll: true });
+  }
+}
+
+function clearFrame() {
+  if (!frameEl) return;
+  try {
+    frameEl.src = "about:blank";
+  } catch (error) {
+    frameEl.removeAttribute("src");
+  }
+}
+
+export function closeFileViewer() {
+  if (!viewerEl) return;
+  viewerEl.hidden = true;
+  viewerEl.setAttribute("aria-hidden", "true");
+  viewerEl.classList.remove("is-visible");
+  clearFrame();
+  if (document.body) {
+    document.body.classList.remove("has-file-viewer");
+  }
+  if (lastActiveElement && typeof lastActiveElement.focus === "function") {
+    lastActiveElement.focus({ preventScroll: true });
+  }
+  lastActiveElement = null;
+}
+
+function attachListeners() {
+  if (!viewerEl || initialized) return;
+  const closeTriggers = viewerEl.querySelectorAll("[data-file-viewer-close]");
+  closeTriggers.forEach((el) => {
+    el.addEventListener("click", (event) => {
+      event.preventDefault();
+      closeFileViewer();
+    });
+  });
+  document.addEventListener("keydown", onKeyDown);
+  document.addEventListener("focus", onFocus, true);
+  initialized = true;
+}
+
+export function initializeFileViewer() {
+  if (!queryElements()) return false;
+  attachListeners();
+  return true;
+}
+
+export function openFileViewer(url, options = {}) {
+  if (!url) return false;
+  if (!queryElements()) {
+    window.open(url, "_blank", "noopener");
+    return false;
+  }
+  attachListeners();
+  lastActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  if (document.body) {
+    document.body.classList.add("has-file-viewer");
+  }
+  viewerEl.hidden = false;
+  viewerEl.setAttribute("aria-hidden", "false");
+  viewerEl.classList.add("is-visible");
+  if (titleEl) {
+    titleEl.textContent = options.title || "Vista previa del archivo";
+  }
+  if (fallbackLinkEl) {
+    const linkUrl = options.downloadUrl || url;
+    fallbackLinkEl.href = linkUrl;
+    if (options.fileName) {
+      fallbackLinkEl.setAttribute("download", options.fileName);
+    } else {
+      fallbackLinkEl.removeAttribute("download");
+    }
+  }
+  if (frameEl) {
+    frameEl.src = url;
+  }
+  if (dialogEl) {
+    dialogEl.focus({ preventScroll: true });
+  }
+  return true;
+}

--- a/js/index-student-uploads.js
+++ b/js/index-student-uploads.js
@@ -1,8 +1,11 @@
 import { onAuth } from "./firebase.js";
+import { initializeFileViewer, openFileViewer } from "./file-viewer.js";
 import {
   observeStudentUploads,
   createStudentUpload,
 } from "./student-uploads.js";
+
+initializeFileViewer();
 
 const titleInput = document.getElementById("studentUploadTitle");
 const typeSelect = document.getElementById("studentUploadType");
@@ -254,13 +257,28 @@ function renderList(items) {
 
     const actions = document.createElement("div");
     actions.className = "student-uploads__item-actions";
+    if (item.fileUrl) {
+      const previewBtn = document.createElement("button");
+      previewBtn.type = "button";
+      previewBtn.className = "student-uploads__item-button";
+      previewBtn.textContent = "Visualizar archivo";
+      previewBtn.addEventListener("click", () => {
+        openFileViewer(item.fileUrl, {
+          title: item.title || "Entrega sin título",
+          downloadUrl: item.fileUrl,
+          fileName: item.fileName || "",
+        });
+      });
+      actions.appendChild(previewBtn);
+    }
+
     const link = document.createElement("a");
     link.className = "student-uploads__item-link";
     if (item.fileUrl) {
       link.href = item.fileUrl;
       link.target = "_blank";
       link.rel = "noopener";
-      link.textContent = "Abrir archivo";
+      link.textContent = "Abrir en pestaña nueva";
     } else {
       link.setAttribute("aria-disabled", "true");
       link.textContent = "Archivo no disponible";

--- a/js/paneldocente-backend.js
+++ b/js/paneldocente-backend.js
@@ -2,6 +2,7 @@
 // Backend para paneldocente.html (docente). Firebase 10.12.3 · ES2015.
 
 import { initFirebase, getDb, onAuth, isTeacherByDoc, isTeacherEmail } from './firebase.js';
+import { initializeFileViewer, openFileViewer } from './file-viewer.js';
 import {
   observeAllStudentUploads,
   markStudentUploadAccepted,
@@ -535,7 +536,11 @@ function buildUploadCard(upload){
 
   html += '<div class="pd-uploads__item-actions">';
   if (upload.fileUrl){
-    html += '<a class="pd-action-btn" href="'+ escAttr(upload.fileUrl) +'" target="_blank" rel="noopener">Abrir archivo</a>';
+    var fileUrlAttr = escAttr(upload.fileUrl);
+    var fileTitleAttr = escAttr(upload.title || 'Entrega sin título');
+    var fileNameAttr = escAttr(upload.fileName || '');
+    html += '<button type="button" class="pd-action-btn pd-uploads__action" data-action="preview" data-file-url="'+ fileUrlAttr +'" data-file-title="'+ fileTitleAttr +'" data-file-name="'+ fileNameAttr +'">Visualizar</button>';
+    html += '<a class="pd-action-btn" href="'+ fileUrlAttr +'" target="_blank" rel="noopener">Abrir en pestaña nueva</a>';
   } else {
     html += '<span class="pd-uploads__item-link-disabled">Archivo no disponible</span>';
   }
@@ -729,6 +734,14 @@ function bindUploadDetail(state){
     var item = btn.closest ? btn.closest('.pd-uploads__item') : null;
     var uploadId = item ? item.getAttribute('data-id') : null;
     if (!uploadId) return;
+    if (action === 'preview'){
+      var url = btn.getAttribute('data-file-url');
+      if (!url) return;
+      var title = btn.getAttribute('data-file-title') || 'Entrega';
+      var fileName = btn.getAttribute('data-file-name') || '';
+      openFileViewer(url, { title: title, downloadUrl: url, fileName: fileName });
+      return;
+    }
     if (action === 'accept'){
       handleAcceptAction(state, uploadId, btn);
     } else if (action === 'grade'){
@@ -963,6 +976,7 @@ async function loadDataForGroup(db, grupo, state){
 // ===== Main =====
 async function main(){
   await ready();
+  initializeFileViewer();
   initFirebase();
   var db = getDb();
 

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -1130,6 +1130,28 @@
       </section>
     </main>
 
+    <div class="file-viewer" id="fileViewer" hidden aria-hidden="true">
+      <div class="file-viewer__backdrop" data-file-viewer-close></div>
+      <div class="file-viewer__dialog" role="dialog" aria-modal="true" aria-labelledby="fileViewerTitle">
+        <header class="file-viewer__header">
+          <h2 class="file-viewer__title" id="fileViewerTitle" data-file-viewer-title>Vista previa del archivo</h2>
+          <button type="button" class="file-viewer__close" aria-label="Cerrar vista previa" data-file-viewer-close>&times;</button>
+        </header>
+        <div class="file-viewer__content">
+          <iframe
+            data-file-viewer-frame
+            title="Vista previa del archivo seleccionado"
+            loading="lazy"
+            allow="fullscreen"
+          ></iframe>
+        </div>
+        <p class="file-viewer__notice">
+          Si el archivo no se muestra correctamente, puedes
+          <a data-file-viewer-download target="_blank" rel="noopener">abrirlo en una pestaña nueva</a>.
+        </p>
+      </div>
+    </div>
+
     <script>
       document.addEventListener('DOMContentLoaded', function () {
         var tabs = document.querySelectorAll('.pd-tab');


### PR DESCRIPTION
## Summary
- add a reusable viewer overlay so docentes y estudiantes puedan visualizar los archivos sin salir del panel
- incorporar botón de visualización en los listados de entregas y mantener acceso a abrir en pestaña nueva
- actualizar estilos globales para el modal y crear módulo compartido que gestiona su apertura y foco

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d576b78f408325b6dd2a2ade89ec7b