### PR TITLE
Link uploads to activities in index and show them on grades view

### DIFF
--- a/calificaciones.html
+++ b/calificaciones.html
@@ -2669,179 +2669,9 @@
 
 
 
+    <script type="module" src="js/calificaciones-uploads-ui.js"></script>
+
     <script>
-
-      const UPLOAD_STORAGE_KEY = "qs-calificaciones-uploads";
-
-      function loadUploadState() {
-        if (typeof window === "undefined" || !window.localStorage) {
-          return {};
-        }
-        try {
-          const stored = window.localStorage.getItem(UPLOAD_STORAGE_KEY);
-          return stored ? JSON.parse(stored) : {};
-        } catch (error) {
-          console.warn(
-            "No fue posible cargar el historial de entregas desde el navegador.",
-            error
-          );
-          return {};
-        }
-      }
-
-      function saveUploadState(state) {
-        if (typeof window === "undefined" || !window.localStorage) {
-          return;
-        }
-        try {
-          window.localStorage.setItem(
-            UPLOAD_STORAGE_KEY,
-            JSON.stringify(state)
-          );
-        } catch (error) {
-          console.warn(
-            "No fue posible guardar el estado de entregas en el navegador.",
-            error
-          );
-        }
-      }
-
-      function initializeUploadControls() {
-        const gradeItems = document.querySelectorAll(
-          "#calificaciones-root .grade-item"
-        );
-        if (!gradeItems.length) {
-          return;
-        }
-
-        const state = loadUploadState();
-        const activeKeys = new Set();
-        const defaultStatus = "Sin archivo cargado";
-
-        gradeItems.forEach((item, index) => {
-          if (item.querySelector(".grade-actions")) {
-            return;
-          }
-
-          const gradeInput =
-            item.querySelector(".grade-input") ||
-            item.querySelector(".project-grade-input");
-          if (!gradeInput) {
-            return;
-          }
-
-          const titleEl = item.querySelector("h3, h4, h5, h6");
-          const activityTitle = titleEl
-            ? titleEl.textContent.trim()
-            : `Actividad ${index + 1}`;
-          const unitWrapper = item.closest(".unit-content");
-          const unitId = (unitWrapper && unitWrapper.id) || "general";
-          const activityKey = `${unitId}::${activityTitle}`;
-          activeKeys.add(activityKey);
-
-          const actions = document.createElement("div");
-          actions.className = "grade-actions";
-
-          const uploadWrapper = document.createElement("div");
-          uploadWrapper.className = "upload-control";
-
-          const fileInput = document.createElement("input");
-          const uploadId = `upload-${index}`;
-          fileInput.type = "file";
-          fileInput.id = uploadId;
-          fileInput.className = "upload-input";
-          fileInput.hidden = true;
-
-          const status = document.createElement("span");
-          status.className = "upload-status";
-          status.id = `upload-status-${index}`;
-          status.setAttribute("aria-live", "polite");
-          status.textContent = defaultStatus;
-
-          const buttonsWrapper = document.createElement("div");
-          buttonsWrapper.className = "upload-control-buttons";
-
-          const triggerButton = document.createElement("button");
-          triggerButton.type = "button";
-          triggerButton.className = "upload-trigger";
-          triggerButton.textContent = "Subir actividad";
-          triggerButton.setAttribute("aria-controls", uploadId);
-
-          const resetButton = document.createElement("button");
-          resetButton.type = "button";
-          resetButton.className = "upload-reset upload-reset--hidden";
-          resetButton.textContent = "Quitar archivo";
-          resetButton.setAttribute("aria-controls", uploadId);
-
-          function setUploadedState(fileName) {
-            status.textContent = `Archivo cargado: ${fileName}`;
-            status.title = fileName;
-            status.classList.add("upload-status--uploaded");
-            resetButton.classList.remove("upload-reset--hidden");
-          }
-
-          function setDefaultState() {
-            status.textContent = defaultStatus;
-            status.title = "";
-            status.classList.remove("upload-status--uploaded");
-            resetButton.classList.add("upload-reset--hidden");
-          }
-
-          const storedInfo = state[activityKey];
-          if (storedInfo && storedInfo.fileName) {
-            setUploadedState(storedInfo.fileName);
-          }
-
-          triggerButton.addEventListener("click", () => {
-            fileInput.click();
-          });
-
-          fileInput.addEventListener("change", () => {
-            const selected = fileInput.files && fileInput.files[0];
-            if (selected) {
-              setUploadedState(selected.name);
-              state[activityKey] = {
-                fileName: selected.name,
-                updatedAt: new Date().toISOString(),
-              };
-              saveUploadState(state);
-            } else {
-              delete state[activityKey];
-              saveUploadState(state);
-              setDefaultState();
-            }
-          });
-
-          resetButton.addEventListener("click", () => {
-            fileInput.value = "";
-            delete state[activityKey];
-            saveUploadState(state);
-            setDefaultState();
-          });
-
-          buttonsWrapper.appendChild(triggerButton);
-          buttonsWrapper.appendChild(resetButton);
-          uploadWrapper.appendChild(fileInput);
-          uploadWrapper.appendChild(buttonsWrapper);
-          uploadWrapper.appendChild(status);
-
-          gradeInput.setAttribute("aria-describedby", status.id);
-
-          actions.appendChild(gradeInput);
-          actions.appendChild(uploadWrapper);
-          item.appendChild(actions);
-        });
-
-        const staleKeys = Object.keys(state).filter(
-          (key) => !activeKeys.has(key)
-        );
-        if (staleKeys.length) {
-          staleKeys.forEach((key) => delete state[key]);
-          saveUploadState(state);
-        }
-      }
-
-      document.addEventListener("DOMContentLoaded", initializeUploadControls);
 
       // Student data
 
@@ -3098,6 +2928,10 @@
         },
 
       ];
+
+      if (typeof window !== "undefined") {
+        window.students = students;
+      }
 
 
 

--- a/index.html
+++ b/index.html
@@ -2216,21 +2216,25 @@
 
               <div class="field">
 
-                <label for="studentUploadTitle">Título de la entrega</label>
+                <label for="studentUploadTitle">Actividad entregada</label>
 
-                <input
-
-                  type="text"
+                <select
 
                   id="studentUploadTitle"
 
                   name="studentUploadTitle"
 
-                  placeholder="Ejemplo: Actividad 3 · Matriz de trazabilidad"
-
                   required
 
-                />
+                >
+
+                  <option value="" disabled selected>
+
+                    Selecciona la actividad o asignación
+
+                  </option>
+
+                </select>
 
               </div>
 

--- a/js/calificaciones-uploads-ui.js
+++ b/js/calificaciones-uploads-ui.js
@@ -1,0 +1,349 @@
+import { onAuth } from "./firebase.js";
+import { initializeFileViewer, openFileViewer } from "./file-viewer.js";
+import {
+  observeStudentUploads,
+  observeStudentUploadsByEmail,
+} from "./student-uploads.js";
+import {
+  getActivityById,
+  findActivityByTitle,
+} from "./course-activities.js";
+
+initializeFileViewer();
+
+const dateFormatter = new Intl.DateTimeFormat("es-MX", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const gradeItemSelector = "#calificaciones-root .grade-item";
+const displays = new Map();
+let unsubscribeUploads = null;
+let currentProfileKey = null;
+let authUser = null;
+let uiReady = false;
+
+function ready() {
+  if (document.readyState === "complete" || document.readyState === "interactive") {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    document.addEventListener("DOMContentLoaded", resolve, { once: true });
+  });
+}
+
+function toTimestamp(value) {
+  if (!value) return 0;
+  if (typeof value.toMillis === "function") {
+    try {
+      return value.toMillis();
+    } catch (_) {
+      return 0;
+    }
+  }
+  if (typeof value.toDate === "function") {
+    try {
+      const date = value.toDate();
+      return date instanceof Date && !Number.isNaN(date.getTime()) ? date.getTime() : 0;
+    } catch (_) {
+      return 0;
+    }
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return date instanceof Date && !Number.isNaN(date.getTime()) ? date.getTime() : 0;
+}
+
+function setStatus(entry, text, { uploaded = false, title = "" } = {}) {
+  if (!entry || !entry.statusEl) return;
+  entry.statusEl.textContent = text;
+  entry.statusEl.title = title;
+  entry.statusEl.classList.toggle("upload-status--uploaded", Boolean(uploaded));
+}
+
+function disableView(entry) {
+  if (!entry || !entry.viewLink) return;
+  entry.viewLink.setAttribute("aria-disabled", "true");
+  entry.viewLink.removeAttribute("target");
+  entry.viewLink.href = "#";
+  entry.viewLink.dataset.url = "";
+  entry.viewLink.dataset.filename = "";
+}
+
+function enableView(entry, url, fileName, title) {
+  if (!entry || !entry.viewLink || !url) return;
+  entry.viewLink.dataset.url = url;
+  entry.viewLink.dataset.filename = fileName || "";
+  entry.viewLink.href = url;
+  entry.viewLink.target = "_blank";
+  entry.viewLink.removeAttribute("aria-disabled");
+  entry.viewLink.addEventListener("click", (event) => {
+    if (!entry.viewLink.dataset.url) {
+      event.preventDefault();
+      return;
+    }
+    event.preventDefault();
+    openFileViewer(entry.viewLink.dataset.url, {
+      title: title || fileName || "Entrega",
+      downloadUrl: entry.viewLink.dataset.url,
+      fileName: entry.viewLink.dataset.filename || "",
+    });
+  });
+}
+
+function resetViewListener(entry) {
+  if (!entry || !entry.viewLink) return;
+  const clone = entry.viewLink.cloneNode(true);
+  entry.viewLink.replaceWith(clone);
+  entry.viewLink = clone;
+}
+
+function buildDisplayForItem(item) {
+  if (!item || item.querySelector(".grade-actions")) return null;
+  const gradeInput = item.querySelector(".grade-input, .project-grade-input");
+  const heading = item.querySelector("h1, h2, h3, h4, h5, h6, strong");
+  const unitEl = item.closest(".unit-content");
+  const title = heading ? heading.textContent.trim() : "";
+  const unitId = unitEl?.id || "";
+  const activity = findActivityByTitle(title, unitId) || findActivityByTitle(title);
+
+  const actions = document.createElement("div");
+  actions.className = "grade-actions";
+
+  if (gradeInput) {
+    actions.appendChild(gradeInput);
+  }
+
+  const viewWrapper = document.createElement("div");
+  viewWrapper.className = "upload-control";
+
+  const buttonsWrapper = document.createElement("div");
+  buttonsWrapper.className = "upload-control-buttons";
+
+  const viewLink = document.createElement("a");
+  viewLink.className = "upload-trigger";
+  viewLink.href = "#";
+  viewLink.setAttribute("aria-disabled", "true");
+  viewLink.textContent = "Visualizar entrega";
+
+  buttonsWrapper.appendChild(viewLink);
+  viewWrapper.appendChild(buttonsWrapper);
+
+  const status = document.createElement("span");
+  status.className = "upload-status";
+  status.setAttribute("aria-live", "polite");
+  status.textContent = activity ? "Sin entrega registrada" : "Actividad no vinculada";
+  const statusId = `upload-status-${displays.size + 1}`;
+  status.id = statusId;
+  viewWrapper.appendChild(status);
+
+  if (gradeInput) {
+    gradeInput.setAttribute("aria-describedby", statusId);
+  }
+
+  actions.appendChild(viewWrapper);
+  item.appendChild(actions);
+
+  const entry = {
+    statusEl: status,
+    viewLink,
+    gradeInput,
+    activity,
+    item,
+    statusId,
+    title,
+  };
+
+  if (!activity) {
+    disableView(entry);
+  } else {
+    resetViewListener(entry);
+  }
+
+  return entry;
+}
+
+function ensureDisplays() {
+  const items = document.querySelectorAll(gradeItemSelector);
+  items.forEach((item) => {
+    const entry = buildDisplayForItem(item);
+    if (!entry) return;
+    const activity = entry.activity;
+    if (!activity || !activity.id) {
+      return;
+    }
+    const existing = displays.get(activity.id);
+    if (!existing) {
+      displays.set(activity.id, entry);
+    }
+  });
+}
+
+function mapUploadsByActivity(items) {
+  const map = new Map();
+  if (!Array.isArray(items)) return map;
+  items.forEach((item) => {
+    if (!item) return;
+    const baseActivity =
+      getActivityById(item?.extra?.activityId) ||
+      (item?.extra?.unitId ? findActivityByTitle(item.title, item.extra.unitId) : null) ||
+      findActivityByTitle(item.title);
+    if (!baseActivity || !baseActivity.id) return;
+    const previous = map.get(baseActivity.id);
+    if (!previous || toTimestamp(item.submittedAt) >= toTimestamp(previous.submittedAt)) {
+      map.set(baseActivity.id, item);
+    }
+  });
+  return map;
+}
+
+function updateDisplays(uploadMap) {
+  displays.forEach((entry, activityId) => {
+    const upload = uploadMap.get(activityId) || null;
+    resetViewListener(entry);
+    if (!upload || !upload.fileUrl) {
+      disableView(entry);
+      const text = entry.activity
+        ? "Sin entrega registrada"
+        : "Actividad no vinculada";
+      setStatus(entry, text, { uploaded: false, title: "" });
+      return;
+    }
+    enableView(entry, upload.fileUrl, upload.fileName || "", entry.activity?.title || entry.title);
+    const submitted = toTimestamp(upload.submittedAt);
+    const submittedDate = submitted ? new Date(submitted) : null;
+    const parts = [];
+    if (upload.fileName) parts.push(upload.fileName);
+    if (submittedDate && !Number.isNaN(submittedDate.getTime())) {
+      parts.push(dateFormatter.format(submittedDate));
+    }
+    const statusText = parts.length ? parts.join(" · ") : "Entrega disponible";
+    setStatus(entry, statusText, {
+      uploaded: true,
+      title: upload.fileName || "",
+    });
+  });
+}
+
+function setLoadingState() {
+  displays.forEach((entry) => {
+    if (!entry.activity || !entry.statusEl) return;
+    setStatus(entry, "Buscando entregas…", { uploaded: false, title: "" });
+    disableView(entry);
+  });
+}
+
+function setErrorState() {
+  displays.forEach((entry) => {
+    if (!entry.activity) return;
+    setStatus(entry, "No fue posible cargar la entrega", { uploaded: false, title: "" });
+    disableView(entry);
+  });
+}
+
+function subscribeToProfile(profile) {
+  if (!uiReady) return;
+  const key = profile
+    ? `${profile.uid || ""}|${(profile.email || "").toLowerCase()}`
+    : "__none__";
+  if (key === currentProfileKey) return;
+  currentProfileKey = key;
+  if (typeof unsubscribeUploads === "function") {
+    try {
+      unsubscribeUploads();
+    } catch (_) {}
+    unsubscribeUploads = null;
+  }
+
+  if (!profile || (!profile.uid && !profile.email)) {
+    updateDisplays(new Map());
+    return;
+  }
+
+  setLoadingState();
+
+  const onChange = (items) => {
+    updateDisplays(mapUploadsByActivity(items));
+  };
+
+  const onError = () => {
+    setErrorState();
+  };
+
+  if (profile.uid) {
+    unsubscribeUploads = observeStudentUploads(profile.uid, onChange, onError);
+  } else if (profile.email) {
+    unsubscribeUploads = observeStudentUploadsByEmail(profile.email, onChange, onError);
+  }
+}
+
+function studentsArray() {
+  return Array.isArray(window.students) ? window.students : [];
+}
+
+function extractEmail(text) {
+  if (!text) return "";
+  const match = String(text).match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  return match ? match[0] : "";
+}
+
+function getSelectedStudentProfile() {
+  const select = document.getElementById("studentSelect");
+  if (!select || !select.value) return null;
+  const option = select.selectedOptions && select.selectedOptions[0];
+  const value = select.value;
+  const email = option?.dataset?.email || option?.getAttribute("data-email") || "";
+  const uid = option?.dataset?.uid || option?.getAttribute("data-uid") || "";
+  const list = studentsArray();
+  const fallback = list.find(
+    (student) => student && (student.id === value || student.uid === value)
+  );
+  const emailField = document.getElementById("studentEmail");
+  const parsedEmail = email || fallback?.email || extractEmail(option?.textContent || "");
+  const effectiveEmail = parsedEmail || (emailField ? emailField.value.trim() : "");
+  const profile = {
+    uid: uid || fallback?.uid || "",
+    email: effectiveEmail,
+  };
+  if (profile.uid || profile.email) return profile;
+  return null;
+}
+
+function handleStudentSelection() {
+  const profile = getSelectedStudentProfile();
+  if (profile) {
+    subscribeToProfile(profile);
+  } else if (authUser) {
+    subscribeToProfile({ uid: authUser.uid, email: authUser.email || "" });
+  } else {
+    subscribeToProfile(null);
+  }
+}
+
+async function main() {
+  await ready();
+  ensureDisplays();
+  uiReady = true;
+  handleStudentSelection();
+
+  const select = document.getElementById("studentSelect");
+  if (select) {
+    select.addEventListener("change", handleStudentSelection);
+  }
+}
+
+onAuth((user) => {
+  authUser = user;
+  if (!uiReady) return;
+  if (!getSelectedStudentProfile()) {
+    if (user) {
+      subscribeToProfile({ uid: user.uid, email: user.email || "" });
+    } else {
+      subscribeToProfile(null);
+    }
+  }
+});
+
+main().catch((error) => {
+  console.error("[calificaciones-uploads-ui]", error);
+  setErrorState();
+});

--- a/js/course-activities.js
+++ b/js/course-activities.js
@@ -1,0 +1,191 @@
+const baseActivities = [
+  {
+    unitId: "unit1",
+    unitLabel: "Unidad 1 · Fundamentos de Calidad de Software",
+    shortLabel: "Unidad 1",
+    items: [
+      { id: "unit1-foro-ejemplo-metricas", title: "Foro: Ejemplo de Métricas" },
+      { id: "unit1-taller-complejidad-ciclomatica", title: "Taller de Complejidad Ciclomática" },
+      { id: "unit1-plan-pruebas-ieee-829", title: "Plan de Pruebas (IEEE 829)" },
+      { id: "unit1-simulacion-revision-tecnica", title: "Simulación de Revisión Técnica" },
+      { id: "unit1-diseno-casos-prueba", title: "Diseño de Casos de Prueba" },
+      { id: "unit1-foro-seguridad", title: "Foro de Seguridad" },
+      {
+        id: "unit1-presentacion-metricas",
+        title: "Presentación de métricas (producto, proceso, proyecto)",
+      },
+      { id: "unit1-participacion-clase", title: "Participación en Clase" },
+      { id: "unit1-examen", title: "Examen Unidad I" },
+    ],
+  },
+  {
+    unitId: "unit2",
+    unitLabel: "Unidad 2 · Modelos y Estándares de Calidad",
+    shortLabel: "Unidad 2",
+    items: [
+      { id: "unit2-role-playing-auditoria", title: "Role-Playing de Auditoría" },
+      {
+        id: "unit2-informe-comparativo-modelos",
+        title: "Informe Comparativo de Modelos",
+      },
+      {
+        id: "unit2-mapa-conceptual-colaborativo",
+        title: "Mapa Conceptual Colaborativo",
+      },
+      { id: "unit2-participacion-clase", title: "Participación en Clase" },
+      { id: "unit2-examen", title: "Examen Unidad II" },
+    ],
+  },
+  {
+    unitId: "unit3",
+    unitLabel: "Unidad 3 · Plan de Certificación de Calidad",
+    shortLabel: "Unidad 3",
+    items: [
+      {
+        id: "unit3-proyecto-fase1-diagnostico",
+        title: "Proyecto Final – Fase 1 (Diagnóstico)",
+      },
+      {
+        id: "unit3-proyecto-fase2-gap-analysis",
+        title: "Proyecto Final – Fase 2 (Gap Analysis)",
+      },
+      {
+        id: "unit3-proyecto-fases-3-4-roadmap",
+        title: "Proyecto Final – Fases 3 y 4 (Roadmap y Gestión de Cambio)",
+      },
+      {
+        id: "unit3-presentacion-proyecto-final",
+        title: "Presentación del Proyecto Final",
+      },
+      {
+        id: "unit3-examen-final-integrador",
+        title: "Examen Final Integrador",
+      },
+    ],
+  },
+  {
+    unitId: "project",
+    unitLabel: "Rúbrica del Proyecto Final – Plan de Certificación de Calidad",
+    shortLabel: "Proyecto Final",
+    items: [
+      {
+        id: "project-fase1-claridad-diagnostico",
+        title: "Claridad y completitud del diagnóstico",
+      },
+      {
+        id: "project-fase1-justificacion-modelo",
+        title: "Justificación de la selección del modelo",
+      },
+      {
+        id: "project-fase1-presentacion-formato",
+        title: "Presentación y formato",
+      },
+      {
+        id: "project-fase2-identificacion-brechas",
+        title: "Identificación de brechas",
+      },
+      {
+        id: "project-fase2-acciones-priorizacion",
+        title: "Acciones recomendadas y priorización",
+      },
+      {
+        id: "project-fase2-claridad-visual",
+        title: "Claridad visual del documento",
+      },
+      {
+        id: "project-roadmap-secuencia-hitos",
+        title: "Secuencia lógica y realista de hitos",
+      },
+      {
+        id: "project-roadmap-factibilidad",
+        title: "Factibilidad de recursos, tiempos y responsables",
+      },
+      {
+        id: "project-roadmap-plan-comunicacion",
+        title: "Plan de comunicación y capacitación",
+      },
+      {
+        id: "project-roadmap-presentacion-formato",
+        title: "Presentación y formato",
+      },
+      {
+        id: "project-presentacion-claridad-estructura",
+        title: "Claridad y estructura de la exposición",
+      },
+      {
+        id: "project-presentacion-dominio-tema",
+        title: "Dominio del tema y respuesta a preguntas",
+      },
+      {
+        id: "project-presentacion-calidad-visuales",
+        title: "Calidad de diapositivas y visuales",
+      },
+      {
+        id: "project-presentacion-valor-negocio",
+        title: "Justificación del valor de negocio (ROI)",
+      },
+      {
+        id: "project-presentacion-trabajo-equipo",
+        title: "Trabajo en equipo y participación equitativa",
+      },
+    ],
+  },
+];
+
+function normalizeActivityTitle(text) {
+  if (!text) return "";
+  return String(text)
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const flatActivities = [];
+const activityById = new Map();
+
+baseActivities.forEach((unit) => {
+  unit.items.forEach((item, index) => {
+    const entry = {
+      id: item.id,
+      title: item.title,
+      unitId: unit.unitId,
+      unitLabel: unit.unitLabel,
+      unitShortLabel: unit.shortLabel || unit.unitLabel,
+      order: index,
+      normalizedTitle: normalizeActivityTitle(item.title),
+    };
+    flatActivities.push(entry);
+    activityById.set(entry.id, entry);
+  });
+});
+
+export const courseActivities = baseActivities.map((unit) => ({
+  unitId: unit.unitId,
+  unitLabel: unit.unitLabel,
+  shortLabel: unit.shortLabel,
+  items: unit.items.map((item) => ({
+    id: item.id,
+    title: item.title,
+  })),
+}));
+
+export function getActivityById(id) {
+  if (!id) return null;
+  return activityById.get(id) || null;
+}
+
+export function findActivityByTitle(title, unitId) {
+  const normalized = normalizeActivityTitle(title);
+  if (!normalized) return null;
+  const matches = flatActivities.filter((item) => item.normalizedTitle === normalized);
+  if (!matches.length) return null;
+  if (unitId) {
+    const matchByUnit = matches.find((item) => item.unitId === unitId);
+    if (matchByUnit) return matchByUnit;
+  }
+  return matches[0];
+}
+
+export { flatActivities, normalizeActivityTitle };


### PR DESCRIPTION
## Summary
- replace the free-text upload title on the home page with a dropdown backed by a shared course activity catalog
- persist activity metadata when students submit evidence and add Firestore observers that can fetch uploads by email
- add a Calificaciones module that maps each grade item to the catalog and surfaces the latest submitted file for the selected student, exposing the static student list globally for reuse

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d57a329cb8832599440330db12ba81