### PR TITLE
Restrict session status editing to teachers and sync via Firestore

### DIFF
--- a/calificaciones.html
+++ b/calificaciones.html
@@ -4109,7 +4109,7 @@
 
 
 
-    <script defer src="js/layout.js"></script>
+    <script type="module" src="js/layout.js"></script>
 
     <script defer src="js/back-home.js"></script>
 

--- a/js/nav-inject.js
+++ b/js/nav-inject.js
@@ -36,7 +36,7 @@
   if (hasLayoutScript) return;
 
   const loader = document.createElement("script");
-  loader.defer = true;
+  loader.type = "module";
   loader.src = layoutSrc;
   loader.setAttribute("data-qs", "layout-loader");
   loader.addEventListener("error", () => {

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -1200,7 +1200,7 @@
     </script>
     <script type="module" src="./js/paneldocente-backend.js"></script>
     <script type="module" src="./js/role-gate.js"></script>
-    <script defer src="./js/layout.js"></script>
+    <script type="module" src="./js/layout.js"></script>
     <script defer src="js/back-home.js"></script>
   </body>
 </html>

--- a/sesion1.html
+++ b/sesion1.html
@@ -1553,6 +1553,6 @@
     <script defer src="js/back-home.js"></script>
     <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion10.html
+++ b/sesion10.html
@@ -1201,7 +1201,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion11.html
+++ b/sesion11.html
@@ -1407,7 +1407,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion12.html
+++ b/sesion12.html
@@ -1208,6 +1208,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion13.html
+++ b/sesion13.html
@@ -422,6 +422,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion14.html
+++ b/sesion14.html
@@ -675,6 +675,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion15.html
+++ b/sesion15.html
@@ -974,6 +974,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion16.html
+++ b/sesion16.html
@@ -1964,6 +1964,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion17.html
+++ b/sesion17.html
@@ -1151,6 +1151,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion18.html
+++ b/sesion18.html
@@ -1552,6 +1552,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion19.html
+++ b/sesion19.html
@@ -1464,7 +1464,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion2.html
+++ b/sesion2.html
@@ -1491,7 +1491,7 @@
 
     <script defer src="js/back-home.js"></script>
     <script defer src="js/nav-inject.js"></script>
-    <script defer src="js/layout.js"></script>
+    <script type="module" src="js/layout.js"></script>
   </body>
 </html>
 

--- a/sesion20.html
+++ b/sesion20.html
@@ -1786,7 +1786,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion21.html
+++ b/sesion21.html
@@ -872,7 +872,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion22.html
+++ b/sesion22.html
@@ -678,7 +678,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion23.html
+++ b/sesion23.html
@@ -1501,7 +1501,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion24.html
+++ b/sesion24.html
@@ -1556,7 +1556,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion25.html
+++ b/sesion25.html
@@ -1532,7 +1532,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion26.html
+++ b/sesion26.html
@@ -1467,7 +1467,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion27.html
+++ b/sesion27.html
@@ -1441,7 +1441,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion28.html
+++ b/sesion28.html
@@ -2286,7 +2286,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion29.html
+++ b/sesion29.html
@@ -1675,7 +1675,7 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>
 

--- a/sesion3.html
+++ b/sesion3.html
@@ -1991,6 +1991,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion30.html
+++ b/sesion30.html
@@ -1655,6 +1655,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion31.html
+++ b/sesion31.html
@@ -1390,6 +1390,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion32.html
+++ b/sesion32.html
@@ -2348,6 +2348,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion33.html
+++ b/sesion33.html
@@ -2215,6 +2215,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion34.html
+++ b/sesion34.html
@@ -2183,6 +2183,6 @@ Este documento describe la estrategia, alcance, recursos y cronograma para las a
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion35.html
+++ b/sesion35.html
@@ -1412,6 +1412,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion36.html
+++ b/sesion36.html
@@ -1534,6 +1534,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion37.html
+++ b/sesion37.html
@@ -763,6 +763,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion38.html
+++ b/sesion38.html
@@ -1194,6 +1194,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion39.html
+++ b/sesion39.html
@@ -1176,6 +1176,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion4.html
+++ b/sesion4.html
@@ -1574,6 +1574,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion40.html
+++ b/sesion40.html
@@ -855,6 +855,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion41.html
+++ b/sesion41.html
@@ -1120,6 +1120,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion42.html
+++ b/sesion42.html
@@ -1422,6 +1422,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion43.html
+++ b/sesion43.html
@@ -1588,6 +1588,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion44.html
+++ b/sesion44.html
@@ -1534,6 +1534,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion45.html
+++ b/sesion45.html
@@ -202,6 +202,6 @@
     </script>
     <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion5.html
+++ b/sesion5.html
@@ -859,6 +859,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion6.html
+++ b/sesion6.html
@@ -2208,6 +2208,6 @@ Copia este contenido y adáptalo a tu presentación.
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion7.html
+++ b/sesion7.html
@@ -1122,6 +1122,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion8.html
+++ b/sesion8.html
@@ -1026,6 +1026,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>

--- a/sesion9.html
+++ b/sesion9.html
@@ -967,6 +967,6 @@
   <script defer src="js/back-home.js"></script>
   <script defer src="js/nav-inject.js"></script>
   
-<script defer src="js/layout.js"></script>
+<script type="module" src="js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- convert layout.js into an ES module and wire session status controls to Firestore so only authenticated teachers can update them
- add read-only styling and accessibility copy for session status buttons when students view the page
- load layout.js as a module across all pages via nav-inject and direct script tags

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d58432a9048325ad8459be9d333250