### PR TITLE
Allow teachers to publish session status updates

### DIFF
--- a/tools/firestore.rules
+++ b/tools/firestore.rules
@@ -118,6 +118,12 @@ service cloud.firestore {
       allow update, delete: if isTeacher();
     }
 
+    match /session-status/{sessionId} {
+      allow read: if isPotros();
+      allow create, update: if isTeacher();
+      allow delete: if false;
+    }
+
     // NOTE: Merge these forum rules into your existing rules if you already have them.
 
     match /users/{userId} {


### PR DESCRIPTION
## Summary
- allow signed-in potros accounts to read session status documents
- grant teachers permission to create and update session status entries while keeping them undeletable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d59a4bd8348325bf0bee9aa04d65ec