### PR TITLE
Adjust login support section layout

### DIFF
--- a/login.html
+++ b/login.html
@@ -12,34 +12,119 @@
         min-height: 100vh;
         display: flex;
         align-items: center;
-        justify-content: center;
-        padding: 16px;
+        justify-content: flex-start;
+        padding: clamp(32px, 10vh, 80px) 16px clamp(48px, 14vh, 96px);
       }
+
+      .auth-layout {
+        width: min(420px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: clamp(20px, 6vw, 32px);
+      }
+
       .card {
         background: rgba(255, 255, 255, 0.95);
-        border-radius: 16px;
-        padding: 32px;
-        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
-        max-width: 400px;
+        border-radius: 18px;
+        padding: clamp(28px, 6vw, 36px);
+        box-shadow: 0 16px 36px rgba(15, 23, 42, 0.16);
         width: 100%;
+        backdrop-filter: blur(12px);
+      }
+
+      .auth-support {
+        display: flex;
+        flex-direction: column;
+        gap: clamp(18px, 4vw, 24px);
+        padding: clamp(22px, 5vw, 30px);
+        border-radius: 20px;
+        background: rgba(15, 23, 42, 0.8);
+        color: #e2e8f0;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        backdrop-filter: blur(14px);
+      }
+
+      .auth-support h3 {
+        margin: 0;
+        font-size: clamp(1.1rem, 3.5vw, 1.3rem);
+        font-weight: 600;
+        color: #f8fafc;
+      }
+
+      .auth-support p {
+        margin: 0;
+        font-size: clamp(0.95rem, 3.2vw, 1rem);
+        line-height: 1.6;
+      }
+
+      .auth-support ul {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        list-style: none;
+      }
+
+      .auth-support li {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        font-size: clamp(0.95rem, 3.2vw, 1rem);
+        color: #c7d2fe;
+      }
+
+      .auth-support svg {
+        flex-shrink: 0;
+        width: 22px;
+        height: 22px;
+      }
+
+      .auth-support > div {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      @media (min-width: 640px) {
+        body {
+          padding-inline: clamp(40px, 10vw, 72px);
+        }
       }
     </style>
   </head>
   <body>
-    <div class="card">
-      <h1 class="text-2xl font-semibold mb-4 text-center">Iniciar sesión</h1>
-      <button
-        id="googleLoginBtn"
-        class="w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-700 text-white rounded-md font-medium flex items-center justify-center gap-2"
-      >
-        <!-- Google logo (simple SVG) -->
-        <svg class="w-5 h-5" viewBox="0 0 488 512" fill="currentColor" aria-hidden="true"><path d="M488 261.8C488 403.3 392.3 512 244.5 512 109.3 512 0 402.8 0 267.5S109.3 23 244.5 23c66.8 0 121.6 24.3 163.8 64.2l-66.5 63.7C306.8 117.9 278.9 105 244.5 105c-85 0-154 69.1-154 154.5s69 154.5 154 154.5c73.9 0 120.3-43.2 134.7-102.8H244.5v-82.3h243.4c2.3 13.2 3.5 26.7 3.5 40.9z"/></svg>
-        Iniciar sesión con Google
-      </button>
-      <div id="errorMessage" class="text-red-600 text-sm mt-4 text-center"></div>
-      <p class="mt-4 text-center text-sm">
-        <a href="index.html" class="text-indigo-600 hover:underline">Regresar al inicio</a>
-      </p>
+    <div class="auth-layout">
+      <div class="card">
+        <h1 class="text-2xl font-semibold mb-4 text-center">Iniciar sesión</h1>
+        <button
+          id="googleLoginBtn"
+          class="w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-700 text-white rounded-md font-medium flex items-center justify-center gap-2"
+        >
+          <!-- Google logo (simple SVG) -->
+          <svg class="w-5 h-5" viewBox="0 0 488 512" fill="currentColor" aria-hidden="true"><path d="M488 261.8C488 403.3 392.3 512 244.5 512 109.3 512 0 402.8 0 267.5S109.3 23 244.5 23c66.8 0 121.6 24.3 163.8 64.2l-66.5 63.7C306.8 117.9 278.9 105 244.5 105c-85 0-154 69.1-154 154.5s69 154.5 154 154.5c73.9 0 120.3-43.2 134.7-102.8H244.5v-82.3h243.4c2.3 13.2 3.5 26.7 3.5 40.9z"/></svg>
+          Iniciar sesión con Google
+        </button>
+        <div id="errorMessage" class="text-red-600 text-sm mt-4 text-center"></div>
+        <p class="mt-4 text-center text-sm">
+          <a href="index.html" class="text-indigo-600 hover:underline">Regresar al inicio</a>
+        </p>
+      </div>
+      <div class="auth-support">
+        <div>
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="headset" class="lucide lucide-headset"><path d="M3 11h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-5Zm0 0a9 9 0 1 1 18 0m0 0v5a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3Z"></path><path d="M21 16v2a4 4 0 0 1-4 4h-5"></path></svg>
+          <h3>¿Necesitas ayuda?</h3>
+          <p>
+            Nuestro equipo académico puede orientarte con la migración de
+            datos o la incorporación de nuevos usuarios.
+          </p>
+        </div>
+        <ul>
+          <li><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="mail" class="lucide lucide-mail"><path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"></path><rect x="2" y="4" width="20" height="16" rx="2"></rect></svg> soporte@itson.edu.mx</li>
+          <li><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="phone" class="lucide lucide-phone"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"></path></svg> (644) 410 9000 ext. 125</li>
+        </ul>
+      </div>
     </div>
     <script type="module">
       import { initFirebase, signInWithGoogleOpen } from './js/firebase.js';


### PR DESCRIPTION
## Summary
- add a dedicated wrapper so the login card and help panel sit higher on the viewport
- introduce styling for the new academic support block with contact details

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d6b1a2f6b08325808ab984419c651a