### PR TITLE
Ajustar soporte del login para alinearlo con auth-hero

### DIFF
--- a/login.html
+++ b/login.html
@@ -12,15 +12,21 @@
         min-height: 100vh;
         display: flex;
         align-items: center;
-        justify-content: flex-start;
+        justify-content: center;
         padding: clamp(32px, 10vh, 80px) 16px clamp(48px, 14vh, 96px);
       }
 
-      .auth-layout {
-        width: min(420px, 100%);
-        display: flex;
-        flex-direction: column;
+      .auth-hero {
+        width: min(920px, 100%);
+        display: grid;
         gap: clamp(20px, 6vw, 32px);
+      }
+
+      @media (min-width: 900px) {
+        .auth-hero {
+          grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
+          align-items: stretch;
+        }
       }
 
       .card {
@@ -35,26 +41,35 @@
       .auth-support {
         display: flex;
         flex-direction: column;
-        gap: clamp(18px, 4vw, 24px);
-        padding: clamp(22px, 5vw, 30px);
-        border-radius: 20px;
-        background: rgba(15, 23, 42, 0.8);
+        gap: clamp(16px, 4vw, 22px);
+        padding: clamp(18px, 4vw, 24px);
+        border-radius: 18px;
+        background: rgba(15, 23, 42, 0.82);
         color: #e2e8f0;
-        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
-        border: 1px solid rgba(148, 163, 184, 0.35);
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.3);
+        border: 1px solid rgba(148, 163, 184, 0.32);
         backdrop-filter: blur(14px);
+        width: min(360px, 100%);
+        margin-inline: auto;
+      }
+
+      @media (min-width: 900px) {
+        .auth-support {
+          margin: 0;
+          align-self: center;
+        }
       }
 
       .auth-support h3 {
         margin: 0;
-        font-size: clamp(1.1rem, 3.5vw, 1.3rem);
+        font-size: clamp(1rem, 3vw, 1.2rem);
         font-weight: 600;
         color: #f8fafc;
       }
 
       .auth-support p {
         margin: 0;
-        font-size: clamp(0.95rem, 3.2vw, 1rem);
+        font-size: clamp(0.9rem, 3vw, 0.97rem);
         line-height: 1.6;
       }
 
@@ -63,28 +78,28 @@
         padding: 0;
         display: flex;
         flex-direction: column;
-        gap: 12px;
+        gap: 10px;
         list-style: none;
       }
 
       .auth-support li {
         display: inline-flex;
         align-items: center;
-        gap: 12px;
-        font-size: clamp(0.95rem, 3.2vw, 1rem);
+        gap: 10px;
+        font-size: clamp(0.9rem, 3vw, 0.97rem);
         color: #c7d2fe;
       }
 
       .auth-support svg {
         flex-shrink: 0;
-        width: 22px;
-        height: 22px;
+        width: 20px;
+        height: 20px;
       }
 
       .auth-support > div {
         display: flex;
         flex-direction: column;
-        gap: 12px;
+        gap: 10px;
       }
 
       @media (min-width: 640px) {
@@ -95,7 +110,7 @@
     </style>
   </head>
   <body>
-    <div class="auth-layout">
+    <div class="auth-hero">
       <div class="card">
         <h1 class="text-2xl font-semibold mb-4 text-center">Iniciar sesión</h1>
         <button


### PR DESCRIPTION
## Summary
- reorganize el layout de autenticación en una rejilla "auth-hero" para controlar el ancho máximo
- reduce el padding, gap y tipografía del bloque de soporte para que armonice con el hero

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6b4ac21a88325a63165c3eb19ff69