### PR TITLE
Clarify session sync permission warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -2621,7 +2621,7 @@
         const ROLE_STORAGE_KEY = "qs_role";
         const PERMISSION_WARNING_ID = "sessionStatusPermissionWarning";
         const PERMISSION_WARNING_MESSAGE =
-          "Tu cuenta no tiene permisos para sincronizar el estado de las sesiones. Los cambios solo se guardarán en este dispositivo.";
+          "Tu cuenta no tiene permisos para sincronizar el estado de las sesiones. Verifica que hayas iniciado sesión con tu cuenta institucional y que esté autorizada como docente. Si el problema persiste, solicita acceso al coordinador.";
 
         const STATUS_LABELS = {
 


### PR DESCRIPTION
## Summary
- clarify the session synchronization warning so it instructs users to sign in with an authorized docente account when permissions are missing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6e40dedfc83258bc731552815cb49