### PR TITLE
Clarify teacher permissions for session sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -2621,7 +2621,7 @@
         const ROLE_STORAGE_KEY = "qs_role";
         const PERMISSION_WARNING_ID = "sessionStatusPermissionWarning";
         const PERMISSION_WARNING_MESSAGE =
-          "Tu cuenta no tiene permisos para sincronizar el estado de las sesiones. Los cambios solo se guardarán en este dispositivo.";
+          "Tu cuenta no tiene permisos para sincronizar el estado de las sesiones. Solo las cuentas @potros registradas como docentes en Firestore (colección teachers o lista de correos autorizados) pueden hacerlo. Si eres docente, solicita que den de alta tu UID o autoricen tu correo institucional.";
 
         const STATUS_LABELS = {
 


### PR DESCRIPTION
## Summary
- update the session sync permission warning to explain that only teacher accounts registered in Firestore can synchronize

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e40dedfc83258bc731552815cb49