### PR TITLE
Load teacher allowlist from Firestore

### DIFF
--- a/asistencia.html
+++ b/asistencia.html
@@ -1259,12 +1259,14 @@
     subscribeTodayAttendanceByUser,
 
     fetchAttendancesByDateRange,
-      
+
     fetchAttendancesByDateRangeByUser,
 
     isTeacherByDoc,
 
-    isTeacherEmail
+    isTeacherEmail,
+
+    ensureTeacherAllowlistLoaded
 
   } from './js/firebase.js';
 
@@ -1686,6 +1688,7 @@
   // Suscripción por rol
 
   onAuth(async (user) => {
+    await ensureTeacherAllowlistLoaded();
 
     currentUserProfile = null;
 

--- a/index.html
+++ b/index.html
@@ -2622,7 +2622,7 @@
         const PERMISSION_WARNING_ID = "sessionStatusPermissionWarning";
         const PERMISSION_WARNING_MESSAGE =
 
-          "Tu cuenta no tiene permisos para sincronizar el estado de las sesiones. Solo las cuentas @potros registradas como docentes en Firestore (colección teachers o lista de correos autorizados) pueden hacerlo. Si eres docente, solicita que den de alta tu UID o autoricen tu correo institucional.";
+          "Tu cuenta no tiene permisos para sincronizar el estado de las sesiones. Solo las cuentas @potros registradas como docentes en Firestore (colección teachers o lista de correos autorizados en config/teacherAllowlist) pueden hacerlo. Si eres docente, solicita que den de alta tu UID o autoricen tu correo institucional.";
 
 
         const STATUS_LABELS = {

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -22,6 +22,11 @@ export const allowedTeacherEmails = [
   "isaac.paniagua@potros.itson.edu.mx"
 ];
 
+// Documento en Firestore que puede contener correos adicionales autorizados
+// como docentes. Debe incluir un arreglo `emails` en minúsculas. Los correos
+// declarados aquí se combinan con la lista estática anterior.
+export const teacherAllowlistDocPath = "config/teacherAllowlist";
+
 // Habilitar o deshabilitar Firebase Storage.
 // Si no puedes crear un bucket en tu región, déjalo en false.
 export const useStorage = false;

--- a/js/forum-init.js
+++ b/js/forum-init.js
@@ -1,5 +1,5 @@
 
-import { initFirebase, onAuth, getAuthInstance, signInWithGooglePotros, signOutCurrent, isTeacherEmail, isTeacherByDoc, ensureTeacherDocForUser, subscribeForumTopics, createForumTopic, subscribeForumReplies, addForumReply, updateForumTopic, deleteForumTopic, deleteForumReply, registerForumReplyReaction } from './firebase.js';
+import { initFirebase, onAuth, getAuthInstance, signInWithGooglePotros, signOutCurrent, isTeacherEmail, isTeacherByDoc, ensureTeacherDocForUser, ensureTeacherAllowlistLoaded, subscribeForumTopics, createForumTopic, subscribeForumReplies, addForumReply, updateForumTopic, deleteForumTopic, deleteForumReply, registerForumReplyReaction } from './firebase.js';
 
 
 initFirebase();
@@ -333,6 +333,7 @@ onAuth(async user => {
   currentUser = user || null;
   const email = user?.email || '';
   isTeacher = false;
+  await ensureTeacherAllowlistLoaded();
   if (user?.uid) {
     try { isTeacher = await isTeacherByDoc(user.uid); } catch(_) {}
   }

--- a/js/paneldocente-backend.js
+++ b/js/paneldocente-backend.js
@@ -1,7 +1,7 @@
 // js/paneldocente-backend.js
 // Backend para paneldocente.html (docente). Firebase 10.12.3 · ES2015.
 
-import { initFirebase, getDb, onAuth, isTeacherByDoc, isTeacherEmail } from './firebase.js';
+import { initFirebase, getDb, onAuth, isTeacherByDoc, isTeacherEmail, ensureTeacherAllowlistLoaded } from './firebase.js';
 import { initializeFileViewer, openFileViewer } from './file-viewer.js';
 import {
   observeAllStudentUploads,
@@ -244,6 +244,7 @@ function setPanelLocked(root, locked){
 async function computeTeacherState(user){
   var email = user && user.email ? user.email : '';
   var teacher = false;
+  await ensureTeacherAllowlistLoaded();
   if (user && user.uid){
     try { teacher = await isTeacherByDoc(user.uid); }
     catch(_){ teacher = false; }

--- a/js/realtime-notifications.js
+++ b/js/realtime-notifications.js
@@ -5,6 +5,7 @@ import {
   isTeacherEmail,
   isTeacherByDoc,
   ensureTeacherDocForUser,
+  ensureTeacherAllowlistLoaded,
   subscribeLatestForumReplies,
   fetchForumTopicSummary,
   fetchForumReply,
@@ -1485,6 +1486,7 @@ function initRealtimeNotifications() {
       if (!user) return false;
       const email = (user.email || "").toLowerCase();
       let teacher = false;
+      await ensureTeacherAllowlistLoaded();
       if (user.uid) {
         try {
           teacher = await isTeacherByDoc(user.uid);
@@ -1508,6 +1510,7 @@ function initRealtimeNotifications() {
 
     try {
       authUnsubscribe = onAuth(async (user) => {
+        await ensureTeacherAllowlistLoaded();
         teacherCheckToken += 1;
         const token = teacherCheckToken;
         const teacher = await determineTeacher(user);

--- a/js/role-gate.js
+++ b/js/role-gate.js
@@ -10,6 +10,7 @@ import {
   isTeacherEmail,
   isTeacherByDoc,
   ensureTeacherDocForUser,
+  ensureTeacherAllowlistLoaded,
 } from "./firebase.js";
 
 initFirebase();
@@ -99,6 +100,7 @@ function applyGradesRole(isTeacher) {
 onAuth(async (user) => {
   const email = user?.email || "";
   let teacher = false;
+  await ensureTeacherAllowlistLoaded();
   if (user?.uid) {
     try {
       teacher = await isTeacherByDoc(user.uid);

--- a/materiales.html
+++ b/materiales.html
@@ -162,9 +162,13 @@
         background: linear-gradient(135deg, #ea580c, #c2410c);
       }
       .file-icon.default {
-        background: linear-gradient(135deg, #6b7280, #4b5563);
-      }
-      .material-title {
+      import { onAuth, isTeacherEmail, ensureTeacherAllowlistLoaded } from "./js/firebase.js";
+      onAuth(async (user) => {
+        if (user) {
+          await ensureTeacherAllowlistLoaded();
+          currentUser = user;
+          isCurrentUserTeacher = isTeacherEmail(user.email);
+          await initializeApp();
         font-size: 1.1rem;
         font-weight: 700;
       }

--- a/tools/firestore.rules
+++ b/tools/firestore.rules
@@ -13,8 +13,22 @@ service cloud.firestore {
         'isaac.paniagua@potros.itson.edu.mx',
       ];
     }
+    function teacherAllowlistDocPath() {
+      return /databases/$(database)/documents/config/teacherAllowlist;
+    }
+    function dynamicTeacherEmails() {
+      return (
+        exists(teacherAllowlistDocPath()) &&
+        get(teacherAllowlistDocPath()).data.emails is list
+      )
+        ? get(teacherAllowlistDocPath()).data.emails
+        : [];
+    }
     function isAllowedTeacherEmail() {
-      return isPotros() && allowedTeacherEmails().hasAny([request.auth.token.email]);
+      return isPotros() && (
+        allowedTeacherEmails().hasAny([request.auth.token.email]) ||
+        dynamicTeacherEmails().hasAny([request.auth.token.email])
+      );
     }
     // Mark teachers by creating a doc at /teachers/{uid}
     function isTeacher() {
@@ -122,6 +136,11 @@ service cloud.firestore {
       allow read: if isPotros();
       allow create, update: if isTeacher();
       allow delete: if false;
+    }
+
+    match /config/{configId} {
+      allow read: if isPotros();
+      allow write: if false;
     }
 
     // NOTE: Merge these forum rules into your existing rules if you already have them.


### PR DESCRIPTION
## Summary
- allow defining extra teacher emails in Firestore at `config/teacherAllowlist` and merge them with the static allowlist
- ensure all role checks load the shared allowlist before determining teacher capabilities across the site
- permit reading the config document via Firestore rules and clarify the sync warning message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6eb2f83648325a19b430e1469d574