### PR TITLE
Remove hero insights panel from landing hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,10 @@
         display: grid;
         gap: 20px;
         align-content: start;
+        justify-items: start;
+        max-width: 720px;
+        margin-inline: auto;
+        text-align: left;
       }
 
       .hero-meta {
@@ -200,119 +204,11 @@
         gap: 12px;
       }
 
-      .hero-insights {
-        display: grid;
-        gap: clamp(18px, 4vw, 24px);
-        align-content: start;
-      }
-
-      @media (min-width: 640px) {
-        .hero-insights {
-          grid-template-columns: repeat(2, minmax(0, 1fr));
-        }
-      }
-
       @media (min-width: 1080px) {
         .hero-card {
-          grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
-          align-items: stretch;
+          max-width: 960px;
+          margin-inline: auto;
         }
-
-        .hero-insights {
-          grid-template-columns: 1fr;
-        }
-      }
-
-      .hero-insight {
-        position: relative;
-        display: grid;
-        gap: 14px;
-        padding: clamp(22px, 4vw, 28px);
-        border-radius: var(--radius-lg);
-        background: rgba(255, 255, 255, 0.92);
-        border: 1px solid rgba(148, 163, 184, 0.28);
-        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
-        overflow: hidden;
-        isolation: isolate;
-      }
-
-      .hero-insight::after {
-        content: "";
-        position: absolute;
-        inset: auto -80px -140px auto;
-        width: 220px;
-        height: 220px;
-        border-radius: 50%;
-        background: radial-gradient(circle, rgba(99, 102, 241, 0.22), transparent 70%);
-        opacity: 0.8;
-        pointer-events: none;
-        z-index: -1;
-      }
-
-      .hero-insight--next {
-        background: linear-gradient(135deg, rgba(99, 102, 241, 0.92), rgba(20, 184, 166, 0.9));
-        border-color: transparent;
-        color: #ffffff;
-        box-shadow: 0 26px 55px rgba(79, 70, 229, 0.35);
-      }
-
-      .hero-insight--next::after {
-        inset: -120px auto auto -80px;
-        background: radial-gradient(circle, rgba(236, 254, 255, 0.35), transparent 70%);
-      }
-
-      .hero-insight__label {
-        font-size: 0.75rem;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        font-weight: 700;
-        color: var(--accent-hover);
-      }
-
-      .hero-insight--next .hero-insight__label {
-        color: rgba(226, 232, 240, 0.78);
-      }
-
-      .hero-insight__value {
-        display: inline-flex;
-        align-items: baseline;
-        gap: 10px;
-      }
-
-      .hero-insight__number {
-        font-size: clamp(2.4rem, 6vw, 3.2rem);
-        font-weight: 700;
-        letter-spacing: -0.04em;
-      }
-
-      .hero-insight__suffix {
-        display: inline-flex;
-        align-items: baseline;
-        gap: 4px;
-        font-size: 0.95rem;
-        font-weight: 600;
-        color: var(--text-secondary);
-      }
-
-      .hero-insight--next .hero-insight__suffix {
-        color: rgba(226, 232, 240, 0.78);
-      }
-
-      .hero-insight__value--text {
-        font-size: clamp(1.4rem, 4vw, 2.2rem);
-        font-weight: 600;
-        letter-spacing: -0.02em;
-      }
-
-      .hero-insight__description {
-        margin: 0;
-        font-size: 0.92rem;
-        line-height: 1.6;
-        color: var(--text-secondary);
-      }
-
-      .hero-insight--next .hero-insight__description {
-        color: rgba(226, 232, 240, 0.85);
       }
 
       .hero-link {
@@ -2096,27 +1992,6 @@
             <a class="hero-link hero-link--primary" href="#sessionsGrid">Explorar sesiones</a>
             <a class="hero-link hero-link--ghost" href="#studentUploadsSection">Registrar entregas</a>
           </div>
-        </div>
-        <div class="hero-insights" aria-label="Resumen del avance del curso">
-          <article class="hero-insight hero-insight--progress">
-            <span class="hero-insight__label">Sesiones completadas</span>
-            <div class="hero-insight__value" aria-live="polite">
-              <span class="hero-insight__number" data-hero-progress>—</span>
-              <span class="hero-insight__suffix">
-                de <span data-hero-total>45</span>
-              </span>
-            </div>
-            <p class="hero-insight__description">
-              Seguimiento temporalmente deshabilitado.
-            </p>
-          </article>
-          <article class="hero-insight hero-insight--next">
-            <span class="hero-insight__label">Siguiente sesión</span>
-            <span class="hero-insight__value hero-insight__value--text" data-hero-next aria-live="polite">Sesión 01</span>
-            <p class="hero-insight__description">
-              Accede rápidamente al próximo encuentro programado.
-            </p>
-          </article>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- remove the hero insights KPI panel from the landing hero
- retune the hero layout so the remaining content stays centered on wide viewports

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68d7202430ac8325b44f533243972705