### PR TITLE
Adjust session grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,8 +535,14 @@
 
       .sessions-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-        gap: 16px;
+        gap: clamp(8px, 1.4vw, 12px);
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      }
+
+      @media (min-width: 1200px) {
+        .sessions-grid {
+          grid-template-columns: repeat(8, minmax(0, 1fr));
+        }
       }
 
       .session-status-note {
@@ -559,7 +565,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 16px;
+        padding: clamp(12px, 2vw, 14px);
         border-radius: 18px;
         background: rgba(248, 250, 252, 0.9);
         border: 1px solid rgba(148, 163, 184, 0.32);
@@ -575,6 +581,10 @@
           box-shadow 0.25s ease,
           background 0.25s ease,
           color 0.25s ease;
+      }
+
+      .session-btn {
+        font-size: clamp(0.85rem, 2vw, 0.95rem);
       }
 
       .session-btn:hover,


### PR DESCRIPTION
## Summary
- reduce the session button footprint on the index page so eight items fit per row on wide screens
- add responsive spacing and typography adjustments to keep the dropdown presentation intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d72381c7e48325bebb9f8561ba28bb