### PR TITLE
feat: permitir gestión de estudiantes desde panel docente

### DIFF
--- a/paneldocente.html
+++ b/paneldocente.html
@@ -332,6 +332,18 @@
         text-align: center;
       }
 
+      .pd-col-actions {
+        width: 180px;
+        text-align: right;
+      }
+
+      .pd-student-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
       .pd-table input[type="checkbox"] {
         width: 18px;
         height: 18px;
@@ -1078,6 +1090,60 @@
             Consulta los promedios por unidad y selecciona estudiantes para enviar recordatorios personalizados.
           </p>
         </div>
+        <article class="pd-card">
+          <div>
+            <h3 id="pd-student-form-title">Agregar estudiante</h3>
+            <p class="pd-subtitle">
+              Registra estudiantes manualmente para reutilizar la plataforma en nuevos grupos.
+            </p>
+          </div>
+          <form id="pd-student-form" class="pd-form" data-mode="create">
+            <div class="pd-form-row cols-2">
+              <label class="pd-field">
+                Nombre completo
+                <input
+                  id="pd-student-name"
+                  name="student-name"
+                  type="text"
+                  autocomplete="name"
+                  placeholder="Ej. Ana Pérez"
+                  required
+                />
+              </label>
+              <label class="pd-field">
+                Correo electrónico
+                <input
+                  id="pd-student-email"
+                  name="student-email"
+                  type="email"
+                  autocomplete="email"
+                  placeholder="nombre@ejemplo.com"
+                  required
+                />
+              </label>
+            </div>
+            <div class="pd-form-row cols-2">
+              <label class="pd-field">
+                Matrícula (opcional)
+                <input
+                  id="pd-student-matricula"
+                  name="student-matricula"
+                  type="text"
+                  autocomplete="off"
+                  placeholder="Ej. A01234567"
+                />
+              </label>
+            </div>
+            <div class="pd-inline-actions">
+              <button id="pd-student-form-submit" class="pd-button primary" type="submit">
+                Agregar estudiante
+              </button>
+              <button id="pd-student-form-cancel" class="pd-button secondary" type="button" hidden>
+                Cancelar edición
+              </button>
+            </div>
+          </form>
+        </article>
         <div class="pd-table-wrap" role="region" aria-live="polite">
           <table class="pd-table">
             <thead>
@@ -1089,10 +1155,11 @@
                 <th scope="col">Unidad II</th>
                 <th scope="col">Unidad III</th>
                 <th scope="col">Final</th>
+                <th scope="col" class="pd-col-actions">Acciones</th>
               </tr>
             </thead>
             <tbody id="pd-students-tbody">
-              <tr><td colspan="7" class="pd-empty">Preparando información de estudiantes…</td></tr>
+              <tr><td colspan="8" class="pd-empty">Preparando información de estudiantes…</td></tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- agrega un formulario en el panel del docente para registrar estudiantes manualmente
- permite editar y eliminar miembros del grupo directamente desde la tabla de estudiantes
- sincroniza métricas y listas de evidencias tras cada cambio en los estudiantes

## Testing
- No se ejecutaron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68d72f5b2b548325a2b8a211cafd078f