### PR TITLE
Avoid Firestore index requirement when filtering uploads by email

### DIFF
--- a/js/student-uploads.js
+++ b/js/student-uploads.js
@@ -198,11 +198,7 @@ export function observeStudentUploadsByEmail(email, onChange, onError) {
 
   variants.forEach(({ field, value, key }) => {
     try {
-      const q = query(
-        uploadsCollection,
-        where(field, "==", value),
-        orderBy("submittedAt", "desc")
-      );
+      const q = query(uploadsCollection, where(field, "==", value));
       const unsubscribe = onSnapshot(
         q,
         (snapshot) => {


### PR DESCRIPTION
## Summary
- stop ordering email-based student upload queries by submittedAt
- allow client-side sorting to avoid needing a composite Firestore index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d881953e6483258411f899a6701eab