### PR TITLE
Simplify forum topic ordering to avoid composite index

### DIFF
--- a/js/firebase.js
+++ b/js/firebase.js
@@ -769,8 +769,7 @@ export function subscribeForumTopics(cb, onError) {
   const db = getDb();
   const qy = query(
     collection(db, "forum_topics"),
-    orderBy("updatedAt", "desc"),
-    orderBy("createdAt", "desc")
+    orderBy("updatedAt", "desc")
   );
   return onSnapshot(
     qy,

--- a/js/forum-init.js
+++ b/js/forum-init.js
@@ -363,7 +363,7 @@ onAuth(async user => {
         if (/permission-denied/i.test(code)) {
           showDebug('Permisos insuficientes. Verifica teachers/{uid} y reglas.', 'warn');
         } else if (/failed-precondition|index/i.test(code)) {
-          showDebug('Se requiere índice compuesto (updatedAt, createdAt). Crea el índice en Firestore.', 'warn');
+          showDebug('Verifica que los documentos tengan el campo updatedAt y que el índice simple sobre updatedAt esté habilitado.', 'warn');
         } else {
           showDebug('Error suscripción temas: ' + code, 'error');
         }


### PR DESCRIPTION
## Summary
- adjust the forum topics subscription to order only by `updatedAt`, avoiding the composite index requirement
- update the forum debug message to reflect the simplified index expectation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d886ac25c48325a481f9f1d87ebaff