### PR TITLE
Document Firestore indexes for student uploads

### DIFF
--- a/tools/firestore.indexes.json
+++ b/tools/firestore.indexes.json
@@ -1,0 +1,23 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "studentUploads",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "student.uid", "order": "ASCENDING" },
+        { "fieldPath": "submittedAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "studentUploads",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "student.emailLower", "order": "ASCENDING" },
+        { "fieldPath": "submittedAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- document the Firestore composite indexes required by the student uploads features
- adjust the email lookup observer to leverage the student.emailLower/submittedAt index

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d888e430008325809986bb994cc8c7