### PR TITLE
Add IMAN student entry to roster data

### DIFF
--- a/asistencia.html
+++ b/asistencia.html
@@ -553,6 +553,7 @@
             {id: "00000216759", name: "Sánchez Zavala, Dulce María", email: "dulce.sanchez216759@potros.itson.edu.mx", type: "student"},
             {id: "00000244689", name: "Villegas Sosa, Ramsés Mauricio", email: "ramses.villegas244689@potros.itson.edu.mx", type: "student"},
             {id: "00000244679", name: "Viveros Zavala, Angel Gael", email: "angel.viveros244679@potros.itson.edu.mx", type: "student"},
+            {id: "", name: "IMAN", email: "iman.guaymas@potros.itson.edu.mx", type: "student"},
             {id: "99645", name: "Paniagua Ruiz, Isaac Noé", email: "isaac.paniagua@potros.itson.edu.mx", type: "teacher"}
 
         ];

--- a/calificaciones.html
+++ b/calificaciones.html
@@ -2947,6 +2947,16 @@
 
         },
 
+        {
+
+          id: "",
+
+          name: "IMAN",
+
+          email: "iman.guaymas@potros.itson.edu.mx",
+
+        },
+
       ];
 
       if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- add IMAN's email to the attendance and grade student rosters so they can be recognized by the site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89cd3eab0832582d34ae36b8ad129