### PR TITLE
Elimina código duplicado en materiales.html

### DIFF
--- a/materiales.html
+++ b/materiales.html
@@ -784,45 +784,6 @@
     <script defer src="js/nav-inject.js"></script>
   </body>
 </html>
-
-          }
-        } else if (button.classList.contains("edit-btn")) {
-          const material = allMaterials.find((m) => m.id === id);
-          const newTitle = prompt("Nuevo título:", material.title);
-          const newDescription = prompt(
-            "Nueva descripción:",
-            material.description
-          );
-          if (newTitle === null || newDescription === null) return;
-          try {
-            await updateMaterial(id, newTitle.trim(), newDescription.trim());
-            material.title = newTitle.trim();
-            material.description = newDescription.trim();
-            render();
-            showNotification("success", "Material actualizado.");
-          } catch (error) {
-            showNotification("error", "No se pudo actualizar.");
-          }
-        }
-      }
-
-      function applyRoleVisibility() {
-        const shouldShowTeacherContent = isCurrentUserTeacher;
-        if (elements.teacherView) {
-          elements.teacherView.classList.toggle(
-            "hidden",
-            !shouldShowTeacherContent
-          );
-        }
-        document.querySelectorAll(".teacher-only").forEach((el) => {
-          const hideElement = !shouldShowTeacherContent;
-          el.classList.toggle("hidden", hideElement);
-          if (hideElement) {
-            el.setAttribute("hidden", "true");
-            el.setAttribute("aria-hidden", "true");
-          } else {
-            el.removeAttribute("hidden");
-            el.removeAttribute("aria-hidden");
           }
         });
       }


### PR DESCRIPTION
## Summary
- remueve un bloque de script duplicado que quedaba fuera del documento HTML en materiales.html
- asegura que sólo se ejecute la versión vigente de los manejadores para renderizar materiales y notificaciones

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8b41da3ec8325a525d9fac3f38076