### PR TITLE
Remove duplicated helper functions from materiales page

### DIFF
--- a/materiales.html
+++ b/materiales.html
@@ -784,25 +784,6 @@
     <script defer src="js/nav-inject.js"></script>
   </body>
 </html>
-          }
-        });
-      }
-
-      function getFileInfo(material) {
-        const ext = material.extension || "";
-        const map = {
-          pdf: "pdf",
-          doc: "doc",
-          docx: "doc",
-          xls: "xls",
-          xlsx: "xls",
-          ppt: "ppt",
-          pptx: "ppt",
-        };
-        return { className: map[ext] || "default", label: ext.toUpperCase() };
-      }
-      function escapeHtml(str) {
-        const p = document.createElement("p");
         p.textContent = str;
         return p.innerHTML;
       }


### PR DESCRIPTION
## Summary
- remove the duplicated helper script that appeared after the closing html tags in materiales.html
- ensure notification helpers and HTML closing tags render only once so the page initializes correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b5205fdc8325ac9a8db827e84ef9