### PR TITLE
Fix leftover script duplication on materiales page

### DIFF
--- a/_check.js
+++ b/_check.js
@@ -74,7 +74,7 @@
             : [];
           materialsData = materials.map(normalizeMaterial);
           if (!materialsData.length) {
-            showEmptyState("Aun no hay materiales disponibles.");
+            showEmptyState("Aún no hay materiales disponibles.");
           } else {
             hideEmptyState();
           }

--- a/materiales.html
+++ b/materiales.html
@@ -786,11 +786,6 @@
   </body>
 </html>
 
-          type === "error" ? "error" : ""
-        }`;
-        elements.notification.classList.add("show");
-        setTimeout(() => elements.notification.classList.remove("show"), 3000);
-      }
     </script>
       <script defer src="js/nav-inject.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove the stray duplicated script block at the end of `materiales.html`
- correct the accent mark in the materials empty state message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8b809cbc083258e636f528d81acc9