### PR TITLE
Remove redundant auth button injection from materials page

### DIFF
--- a/js/role-gate.js
+++ b/js/role-gate.js
@@ -52,19 +52,11 @@ function applyMaterialsRole(isTeacher) {
     isTeacher ? "teacherBtn" : "studentBtn"
   );
   if (active) active.classList.add("active");
-  // Inject auth button in header
-  const roleToggle = document.querySelector(".role-toggle");
-  const authBtn = upsertAuthButton(
-    roleToggle || document.querySelector(".header-content")
-  );
-  authBtn.textContent = getAuthInstance()?.currentUser
-    ? "Cerrar sesion"
-    : "Iniciar sesion";
-  authBtn.onclick = async () => {
-    const auth = getAuthInstance();
-    if (auth?.currentUser) await signOutCurrent();
-    else await signInWithGooglePotros();
-  };
+  // Remove legacy auth button injected directly on materiales.html.
+  const legacyAuthBtn = document.getElementById("qs-auth-btn");
+  if (legacyAuthBtn) {
+    legacyAuthBtn.remove();
+  }
 }
 
 function applyGradesRole(isTeacher) {


### PR DESCRIPTION
## Summary
- stop injecting the legacy qs-auth-btn in materiales.html via role-gate
- clean up any leftover qs-auth-btn element so the page no longer shows the button

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8b933f908832590dfa5ed1e09934e