### PR TITLE
Uniforma los botones de las tarjetas de materiales

### DIFF
--- a/materiales.html
+++ b/materiales.html
@@ -237,8 +237,8 @@
       }
 
       .material-actions {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 12px;
       }
 
@@ -253,10 +253,22 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        gap: 8px;
-        flex: 1 1 0;
-        min-height: 48px;
+        gap: 10px;
+        min-height: 52px;
         text-align: center;
+        width: 100%;
+      }
+
+      .action-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        font-size: 1.15rem;
+      }
+
+      .action-label {
+        flex: 1;
       }
 
       .action-btn:hover {
@@ -361,12 +373,11 @@
         }
 
         .material-actions {
-          flex-direction: column;
+          grid-template-columns: 1fr;
         }
 
         .action-btn {
           width: 100%;
-          flex: 1 1 auto;
         }
       }
     </style>
@@ -587,13 +598,22 @@
             <div class="material-actions">
               <button class="action-btn download-btn" data-action="download" data-id="${
                 material?.id || ""
-              }" data-url="${url}">⬇️ Descargar</button>
+              }" data-url="${url}">
+                <span class="action-icon" aria-hidden="true">⬇️</span>
+                <span class="action-label">Descargar</span>
+              </button>
               <button class="action-btn edit-btn teacher-only" data-action="edit" data-id="${
                 material?.id || ""
-              }">✏️ Editar</button>
+              }">
+                <span class="action-icon" aria-hidden="true">✏️</span>
+                <span class="action-label">Editar</span>
+              </button>
               <button class="action-btn delete-btn teacher-only" data-action="delete" data-id="${
                 material?.id || ""
-              }">🗑️ Eliminar</button>
+              }">
+                <span class="action-icon" aria-hidden="true">🗑️</span>
+                <span class="action-label">Eliminar</span>
+              </button>
             </div>
           </article>
         `;


### PR DESCRIPTION
## Summary
- ajusta la cuadrícula de acciones de las tarjetas de materiales para que los botones tengan el mismo tamaño
- incorpora contenedores de icono y etiqueta para alinear los pictogramas en cada botón
- adapta el diseño responsivo para mantener la distribución en pantallas pequeñas

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8be4788788325bd28ffbfa98aa97d