### PR TITLE
Uniformiza la presentación de las tarjetas de materiales

### DIFF
--- a/materiales.html
+++ b/materiales.html
@@ -166,6 +166,7 @@
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
         gap: clamp(24px, 4vw, 32px);
+        align-items: stretch;
       }
 
       .material-card {
@@ -173,9 +174,11 @@
         border-radius: clamp(18px, 3vw, 24px);
         border: 1px solid rgba(203, 213, 225, 0.45);
         padding: clamp(24px, 4vw, 32px);
-        display: grid;
+        display: flex;
+        flex-direction: column;
         gap: clamp(16px, 3vw, 20px);
         box-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+        height: 100%;
       }
 
       .material-header {
@@ -234,11 +237,12 @@
         margin: 0;
         color: #475569;
         line-height: 1.7;
+        flex: 1;
       }
 
       .material-actions {
         display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
         gap: 12px;
       }
 


### PR DESCRIPTION
## Summary
- ajusta la tarjeta de materiales para que use un diseño en columna y conserve el mismo alto
- mejora la cuadrícula de acciones para que los botones ocupen un ancho uniforme en cualquier rol

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8c1d2422883259e286159ac1dae9f