### PR TITLE
Add Uploadcare backend for calificaciones evidence uploads

### DIFF
--- a/calificaciones.html
+++ b/calificaciones.html
@@ -13,6 +13,15 @@
     <link rel="stylesheet" href="css/layout.css" />
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      UPLOADCARE_PUBLIC_KEY = "85eb5471d305dcd08e71";
+      UPLOADCARE_LOCALE = "es";
+    </script>
+    <script
+      src="https://ucarecdn.com/libs/widget/3.x/uploadcare.full.min.js"
+      charset="utf-8"
+      defer
+    ></script>
 
     <style>
 


### PR DESCRIPTION
## Summary
- load the Uploadcare widget on the calificaciones view so evidence uploads can use the same service as the student portal
- detect Uploadcare availability in the grading uploader and prefer it over Firebase Storage while still falling back when storage is available
- persist metadata from Uploadcare uploads so the evidence list stays synchronized for both teachers and students

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8cd42db1c8325a766a0d6320efde9