### PR TITLE
Add local student database fallback for teacher panel

### DIFF
--- a/data/students.json
+++ b/data/students.json
@@ -1,0 +1,47 @@
+{
+  "generated_at": "2024-06-01T00:00:00Z",
+  "students": [
+    {
+      "uid": "jHIKReRl9SSCf79OhWNU",
+      "displayName": "Iman Pruebas",
+      "email": "iman.guaymas@potros.itson.edu.mx",
+      "matricula": "A01230001",
+      "grades": { "u1": 0, "u2": 0, "u3": 0 }
+    },
+    {
+      "uid": "pd-fb-001",
+      "displayName": "Mariana Castillo",
+      "email": "mariana.castillo@potros.itson.edu.mx",
+      "matricula": "A01230002",
+      "grades": { "u1": 78, "u2": 82, "u3": 88 }
+    },
+    {
+      "uid": "pd-fb-002",
+      "displayName": "Luis Hernández",
+      "email": "luis.hernandez@potros.itson.edu.mx",
+      "matricula": "A01230003",
+      "grades": { "u1": 91, "u2": 95, "u3": 89 }
+    },
+    {
+      "uid": "pd-fb-003",
+      "displayName": "Ana López",
+      "email": "ana.lopez@potros.itson.edu.mx",
+      "matricula": "A01230004",
+      "grades": { "u1": 84, "u2": 80, "u3": 92 }
+    },
+    {
+      "uid": "pd-fb-004",
+      "displayName": "Carlos Méndez",
+      "email": "carlos.mendez@potros.itson.edu.mx",
+      "matricula": "A01230005",
+      "grades": { "u1": 70, "u2": 76, "u3": 82 }
+    },
+    {
+      "uid": "pd-fb-005",
+      "displayName": "Sofía Ramírez",
+      "email": "sofia.ramirez@potros.itson.edu.mx",
+      "matricula": "A01230006",
+      "grades": { "u1": 88, "u2": 90, "u3": 94 }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a local JSON fallback with sample students and grades for the teacher panel
- extend paneldocente backend to load, render, and persist edits against the fallback roster when Firebase data is unavailable
- keep edit and delete actions functional offline by updating the in-memory cache and localStorage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d961941a608325b648a5ebbb3bc05b