### PR TITLE
Allow docente panel access for Iman Guaymas

### DIFF
--- a/js/paneldocente-backend.js
+++ b/js/paneldocente-backend.js
@@ -209,6 +209,7 @@ function groupUploadsByKind(list){
 
 var DATA_ADMIN_ALLOWLIST = {
   'isaac.paniagua@potros.itson.edu.mx': true,
+  'iman.guaymas@potros.itson.edu.mx': true,
 };
 
 function isDataAdminUser(user){


### PR DESCRIPTION
## Summary
- allow the docente panel Firebase data console to recognize iman.guaymas@potros.itson.edu.mx as a data administrator

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d98df792108325871f20b426d028e0