### PR TITLE
Align grade document IDs with Firebase UIDs

### DIFF
--- a/js/calificaciones-helpers.js
+++ b/js/calificaciones-helpers.js
@@ -14,27 +14,40 @@ function sanitizeIdentifier(value) {
 }
 
 export function getPrimaryDocId(profile = {}) {
+  const rawUid = profile.uid != null ? String(profile.uid).trim() : "";
+  if (rawUid) return rawUid;
+
   const emailKey = sanitizeIdentifier(profile.email);
   if (emailKey) return `email-${emailKey}`;
+
   const idKey = sanitizeIdentifier(
     profile.id || profile.studentId || profile.matricula
   );
   if (idKey) return `id-${idKey}`;
+
   const uidKey = sanitizeIdentifier(profile.uid);
   if (uidKey) return `uid-${uidKey}`;
+
   return null;
 }
 
 export function buildCandidateDocIds(profile = {}) {
   const ids = [];
+
+  const rawUid = profile.uid != null ? String(profile.uid).trim() : "";
+  if (rawUid) ids.push(rawUid);
+
   const emailKey = sanitizeIdentifier(profile.email);
   if (emailKey) ids.push(`email-${emailKey}`);
+
   const idKey = sanitizeIdentifier(
     profile.id || profile.studentId || profile.matricula
   );
   if (idKey) ids.push(`id-${idKey}`);
-  const uidKey = sanitizeIdentifier(profile.uid);
-  if (uidKey) ids.push(`uid-${uidKey}`);
+
+  const sanitizedUid = sanitizeIdentifier(profile.uid);
+  if (sanitizedUid) ids.push(`uid-${sanitizedUid}`);
+
   return Array.from(new Set(ids.filter(Boolean)));
 }
 


### PR DESCRIPTION
## Summary
- ensure the teacher sync migrates grade documents to the student's Firebase UID and removes legacy fallback entries
- preserve existing grade metadata while rewriting documents so attendance and grade records share identifiers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9d3a412888325a9e148bdf512a11a