### PR TITLE
Add offline fallback roster to panel docente

### DIFF
--- a/js/paneldocente-app.js
+++ b/js/paneldocente-app.js
@@ -93,6 +93,27 @@ const refreshUploadsBtn = document.getElementById("pd-refresh-uploads");
 const materialForm = document.getElementById("pd-material-form");
 const materialsList = document.getElementById("pd-materials-list");
 
+const membersFallbackEl = document.getElementById("pd-members-fallback");
+if (membersFallbackEl) {
+  try {
+    const fallbackData = JSON.parse(membersFallbackEl.textContent || "{}");
+    const members = Array.isArray(fallbackData.members) ? fallbackData.members : [];
+    if (members.length) {
+      state.members = members.map((member) => ({
+        uid: member.uid || member.id || member.matricula || "",
+        id: member.id || member.uid || member.matricula || "",
+        matricula: member.matricula || member.id || member.uid || "",
+        displayName: member.displayName || member.nombre || "",
+        nombre: member.nombre || member.displayName || "",
+        email: member.email || "",
+        updatedAt: member.updatedAt || null
+      }));
+    }
+  } catch (error) {
+    console.warn("members fallback parse", error);
+  }
+}
+
 const allowlistForm = document.getElementById("pd-allowlist-form");
 const allowlistViewBtn = document.getElementById("pd-load-allowlist");
 const allowlistView = document.getElementById("pd-allowlist-view");

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -576,6 +576,153 @@
               </table>
             </div>
           </article>
+          <script type="application/json" id="pd-members-fallback">
+            {
+              "updatedAt": "2025-09-22T18:00:39-07:00",
+              "members": [
+                {
+                  "uid": "in6tomZxWFhMbJ2W89kcVnFjKTx2",
+                  "matricula": "249116",
+                  "displayName": "Arana Guerrero, Danett Itzanami",
+                  "email": "danett.arana249116@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:15:11-07:00"
+                },
+                {
+                  "uid": "Qff5rjRcvDQrRHMCLRuQRHrUggI2",
+                  "matricula": "147818",
+                  "displayName": "Araujo Godoy, Abraham Francisco",
+                  "email": "abraham.araujo@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:08:46-07:00"
+                },
+                {
+                  "uid": "tMQg4fl8v0TxZvy6NrYNAzSFWua2",
+                  "matricula": "244228",
+                  "displayName": "Avalos Morales, Egla Icel",
+                  "email": "egla.avalos244228@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:02:08-07:00"
+                },
+                {
+                  "uid": "qApbgYiBvBf5nuGJwkRfrgdvxaP2",
+                  "matricula": "244442",
+                  "displayName": "Blasco Villagomez, Luis Mario",
+                  "email": "luis.blasco244442@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:00:24-07:00"
+                },
+                {
+                  "uid": "a5jZkmWDR6YnYbbFGtaSZTQsj8I3",
+                  "matricula": "244242",
+                  "displayName": "Duarte Lopez, Adlemi Guadalupe",
+                  "email": "adlemi.duarte244242@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:05:21-07:00"
+                },
+                {
+                  "uid": "XovrN93okGeVaT9IqBzLEqAWGfN2",
+                  "matricula": "244473",
+                  "displayName": "Espericueta Ramos, Jesus Alan",
+                  "email": "jesus.espericueta244473@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:05:10-07:00"
+                },
+                {
+                  "uid": "EbhoRku5IDdSPP3iFCBb5kJ9tCo2",
+                  "matricula": "244608",
+                  "displayName": "Gracia Morales, Sergio Alejandro",
+                  "email": "sergio.gracia244608@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:17:14-07:00"
+                },
+                {
+                  "uid": "qI5yg45X9SNKC6cNojQRTN4cruZ2",
+                  "matricula": "228847",
+                  "displayName": "Hernandez Gonzalez, Julian Ricardo",
+                  "email": "julian.hernandez228847@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:05:56-07:00"
+                },
+                {
+                  "uid": "Yzo5O1akFZXpfY4LNbPz10inJVi1",
+                  "matricula": "248997",
+                  "displayName": "Le Blohic Garay, Mario Enrique",
+                  "email": "mario.leblohic248997@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:05:33-07:00"
+                },
+                {
+                  "uid": "pkVboPZbemSgebTeA4Utkv3aUwI3",
+                  "matricula": "249012",
+                  "displayName": "Lopez Guerrero, Luis Carlos",
+                  "email": "luis.lopez249012@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:04:30-07:00"
+                },
+                {
+                  "uid": "hC61c739fAeLKJeg7ol6xu6ieq83",
+                  "matricula": "244321",
+                  "displayName": "Nevescanin Moreno, Angel Stipe",
+                  "email": "angel.nevescanin244321@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:02:21-07:00"
+                },
+                {
+                  "uid": "244477",
+                  "matricula": "244477",
+                  "displayName": "Osuna Aguilera, Erik David",
+                  "email": "erik.osuna244477@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-16T19:12:43-07:00"
+                },
+                {
+                  "uid": "244711",
+                  "matricula": "244711",
+                  "displayName": "Palacios Cardenas, Jorge Eduardo",
+                  "email": "jorge.palacios244711@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-16T09:31:14-07:00"
+                },
+                {
+                  "uid": "H1ODGSDs7oUph9PBw6Lg0Jv8Wnw2",
+                  "matricula": "244569",
+                  "displayName": "Preciado Ruiz, Juan Carlos",
+                  "email": "juan.preciado244569@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-22T18:00:39-07:00"
+                },
+                {
+                  "uid": "244373",
+                  "matricula": "244373",
+                  "displayName": "Reyes Galaz, Jose Abelardo",
+                  "email": "jose.reyes244373@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-17T11:53:32-07:00"
+                },
+                {
+                  "uid": "nbkqrDn6NBhtUyDQkNqjLppYs0H3",
+                  "matricula": "240691",
+                  "displayName": "Rivas Quintana, Emmanuel",
+                  "email": "emmanuel.rivas240691@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:11:45-07:00"
+                },
+                {
+                  "uid": "BJpwXy5cdVMPTMVcXPLjiWW06R73",
+                  "matricula": "244266",
+                  "displayName": "Rocha Aguilar, Víctor Emmanuel",
+                  "email": "victor.rocha244266@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-22T18:00:10-07:00"
+                },
+                {
+                  "uid": "o2cx6nR0o5eqfPW9KNLcACmC7rF3",
+                  "matricula": "244312",
+                  "displayName": "Rodriguez Alvarado, Jose Agustin",
+                  "email": "jose.rodriguez244312@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:03:36-07:00"
+                },
+                {
+                  "uid": "T2KEeahFMmcnzL909OBJnOUnjJc2",
+                  "matricula": "244621",
+                  "displayName": "Soto Carrazco, Francisco Javier",
+                  "email": "francisco.soto244621@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:18:33-07:00"
+                },
+                {
+                  "uid": "qqfwGF092ONfselrklTMkGgTujx1",
+                  "matricula": "244679",
+                  "displayName": "Viveros Zavala, Angel Gael",
+                  "email": "angel.viveros244679@potros.itson.edu.mx",
+                  "updatedAt": "2025-09-19T18:08:59-07:00"
+                }
+              ]
+            }
+          </script>
         </section>
 
         <section data-view-panel="uploads">


### PR DESCRIPTION
## Summary
- add a fallback JSON payload with the latest roster of alumnos (sin docentes) to `paneldocente.html`
- hydrate the teacher panel state from the fallback roster so the tabla de alumnos muestra los UID proporcionados sin esperar a Firebase

## Testing
- not run (requires autenticación de Firebase)


------
https://chatgpt.com/codex/tasks/task_e_68d9d91b6f2c832593aab46b17e83c36