### PR TITLE
Align rosters with attendance

### DIFF
--- a/calificaciones.html
+++ b/calificaciones.html
@@ -2799,9 +2799,11 @@
 
           id: "00000249116",
 
-          name: "Arana Guerrero,Danett Itzanami",
+          name: "Arana Guerrero, Danett Itzanami",
 
           email: "danett.arana249116@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2809,9 +2811,11 @@
 
           id: "00000147818",
 
-          name: "Araujo Godoy,Abraham Francisco",
+          name: "Araujo Godoy, Abraham Francisco",
 
           email: "abraham.araujo@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2819,9 +2823,11 @@
 
           id: "00000244228",
 
-          name: "Avalos Morales,Egla Icel",
+          name: "Avalos Morales, Egla Icel",
 
           email: "egla.avalos244228@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2829,9 +2835,11 @@
 
           id: "00000244442",
 
-          name: "Blasco Villagomez,Luis Mario",
+          name: "Blasco Villagomez, Luis Mario",
 
           email: "luis.blasco244442@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2839,9 +2847,11 @@
 
           id: "00000244242",
 
-          name: "Duarte Lopez,Adlemi Guadalupe",
+          name: "Duarte Lopez, Adlemi Guadalupe",
 
           email: "adlemi.duarte244242@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2849,9 +2859,11 @@
 
           id: "00000244473",
 
-          name: "Espericueta Ramos,Jesus Alan",
+          name: "Espericueta Ramos, Jesus Alan",
 
           email: "jesus.espericueta244473@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2859,9 +2871,11 @@
 
           id: "00000244608",
 
-          name: "Gracia Morales,Sergio Alejandro",
+          name: "Gracia Morales, Sergio Alejandro",
 
           email: "sergio.gracia244608@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2869,9 +2883,11 @@
 
           id: "00000228847",
 
-          name: "Hernandez Gonzalez,Julian Ricardo",
+          name: "Hernandez Gonzalez, Julian Ricardo",
 
           email: "julian.hernandez228847@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2879,9 +2895,11 @@
 
           id: "00000248997",
 
-          name: "Le Blohic Garay,Mario Enrique",
+          name: "Le Blohic Garay, Mario Enrique",
 
           email: "mario.leblohic248997@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2889,9 +2907,11 @@
 
           id: "00000249012",
 
-          name: "Lopez Guerrero,Luis Carlos",
+          name: "Lopez Guerrero, Luis Carlos",
 
           email: "luis.lopez249012@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2899,9 +2919,11 @@
 
           id: "00000248990",
 
-          name: "Maldonado Montoya,Jose Gabriel",
+          name: "Maldonado Montoya, Jose Gabriel",
 
           email: "jose.maldonado248990@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2909,9 +2931,11 @@
 
           id: "00000244378",
 
-          name: "Martínez Santacruz,Yolanda",
+          name: "Martínez Santacruz, Yolanda",
 
           email: "yolanda.martinez244378@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2919,9 +2943,11 @@
 
           id: "00000217812",
 
-          name: "Martínez Soto,Dainiz Raí",
+          name: "Martínez Soto, Dainiz Raí",
 
           email: "dainiz.martinez217812@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2929,9 +2955,11 @@
 
           id: "00000244321",
 
-          name: "Nevescanin Moreno,Angel Stipe",
+          name: "Nevescanin Moreno, Angel Stipe",
 
           email: "angel.nevescanin244321@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2939,9 +2967,11 @@
 
           id: "00000244477",
 
-          name: "Osuna Aguilera,Erik David",
+          name: "Osuna Aguilera, Erik David",
 
           email: "erik.osuna244477@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2949,9 +2979,11 @@
 
           id: "00000244711",
 
-          name: "Palacios Cardenas,Jorge Eduardo",
+          name: "Palacios Cardenas, Jorge Eduardo",
 
           email: "jorge.palacios244711@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2959,9 +2991,11 @@
 
           id: "00000244569",
 
-          name: "Preciado Ruiz,Juan Carlos",
+          name: "Preciado Ruiz, Juan Carlos",
 
           email: "juan.preciado244569@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2969,9 +3003,11 @@
 
           id: "00000244373",
 
-          name: "Reyes Galaz,Jose Abelardo",
+          name: "Reyes Galaz, Jose Abelardo",
 
           email: "jose.reyes244373@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2979,9 +3015,11 @@
 
           id: "00000240691",
 
-          name: "Rivas Quintana,Emmanuel",
+          name: "Rivas Quintana, Emmanuel",
 
           email: "emmanuel.rivas240691@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2989,9 +3027,11 @@
 
           id: "00000244266",
 
-          name: "Rocha Aguilar,Víctor Emmanuel",
+          name: "Rocha Aguilar, Víctor Emmanuel",
 
           email: "victor.rocha244266@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -2999,9 +3039,11 @@
 
           id: "00000244312",
 
-          name: "Rodriguez Alvarado,Jose Agustin",
+          name: "Rodriguez Alvarado, Jose Agustin",
 
           email: "jose.rodriguez244312@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -3009,9 +3051,11 @@
 
           id: "00000244621",
 
-          name: "Soto Carrazco,Francisco Javier",
+          name: "Soto Carrazco, Francisco Javier",
 
           email: "francisco.soto244621@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -3019,9 +3063,11 @@
 
           id: "00000216759",
 
-          name: "Sánchez Zavala,Dulce María",
+          name: "Sánchez Zavala, Dulce María",
 
           email: "dulce.sanchez216759@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -3029,9 +3075,11 @@
 
           id: "00000244689",
 
-          name: "Villegas Sosa,Ramsés Mauricio",
+          name: "Villegas Sosa, Ramsés Mauricio",
 
           email: "ramses.villegas244689@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 
@@ -3039,9 +3087,11 @@
 
           id: "00000244679",
 
-          name: "Viveros Zavala,Angel Gael",
+          name: "Viveros Zavala, Angel Gael",
 
           email: "angel.viveros244679@potros.itson.edu.mx",
+
+          type: "student",
 
         },
 

--- a/paneldocente.html
+++ b/paneldocente.html
@@ -571,154 +571,363 @@
                   </tr>
                 </thead>
                 <tbody id="pd-members-body">
-                  <tr><td colspan="5" class="pd-empty">Sin alumnos registrados.</td></tr>
+                  <tr data-member-id="00000249116">
+                    <td>Arana Guerrero, Danett Itzanami</td>
+                    <td>00000249116</td>
+                    <td>danett.arana249116@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000147818">
+                    <td>Araujo Godoy, Abraham Francisco</td>
+                    <td>00000147818</td>
+                    <td>abraham.araujo@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244228">
+                    <td>Avalos Morales, Egla Icel</td>
+                    <td>00000244228</td>
+                    <td>egla.avalos244228@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244442">
+                    <td>Blasco Villagomez, Luis Mario</td>
+                    <td>00000244442</td>
+                    <td>luis.blasco244442@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244242">
+                    <td>Duarte Lopez, Adlemi Guadalupe</td>
+                    <td>00000244242</td>
+                    <td>adlemi.duarte244242@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244473">
+                    <td>Espericueta Ramos, Jesus Alan</td>
+                    <td>00000244473</td>
+                    <td>jesus.espericueta244473@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244608">
+                    <td>Gracia Morales, Sergio Alejandro</td>
+                    <td>00000244608</td>
+                    <td>sergio.gracia244608@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000228847">
+                    <td>Hernandez Gonzalez, Julian Ricardo</td>
+                    <td>00000228847</td>
+                    <td>julian.hernandez228847@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000248997">
+                    <td>Le Blohic Garay, Mario Enrique</td>
+                    <td>00000248997</td>
+                    <td>mario.leblohic248997@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000249012">
+                    <td>Lopez Guerrero, Luis Carlos</td>
+                    <td>00000249012</td>
+                    <td>luis.lopez249012@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000248990">
+                    <td>Maldonado Montoya, Jose Gabriel</td>
+                    <td>00000248990</td>
+                    <td>jose.maldonado248990@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244378">
+                    <td>Martínez Santacruz, Yolanda</td>
+                    <td>00000244378</td>
+                    <td>yolanda.martinez244378@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000217812">
+                    <td>Martínez Soto, Dainiz Raí</td>
+                    <td>00000217812</td>
+                    <td>dainiz.martinez217812@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244321">
+                    <td>Nevescanin Moreno, Angel Stipe</td>
+                    <td>00000244321</td>
+                    <td>angel.nevescanin244321@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244477">
+                    <td>Osuna Aguilera, Erik David</td>
+                    <td>00000244477</td>
+                    <td>erik.osuna244477@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244711">
+                    <td>Palacios Cardenas, Jorge Eduardo</td>
+                    <td>00000244711</td>
+                    <td>jorge.palacios244711@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244569">
+                    <td>Preciado Ruiz, Juan Carlos</td>
+                    <td>00000244569</td>
+                    <td>juan.preciado244569@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244373">
+                    <td>Reyes Galaz, Jose Abelardo</td>
+                    <td>00000244373</td>
+                    <td>jose.reyes244373@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000240691">
+                    <td>Rivas Quintana, Emmanuel</td>
+                    <td>00000240691</td>
+                    <td>emmanuel.rivas240691@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244266">
+                    <td>Rocha Aguilar, Víctor Emmanuel</td>
+                    <td>00000244266</td>
+                    <td>victor.rocha244266@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244312">
+                    <td>Rodriguez Alvarado, Jose Agustin</td>
+                    <td>00000244312</td>
+                    <td>jose.rodriguez244312@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244621">
+                    <td>Soto Carrazco, Francisco Javier</td>
+                    <td>00000244621</td>
+                    <td>francisco.soto244621@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000216759">
+                    <td>Sánchez Zavala, Dulce María</td>
+                    <td>00000216759</td>
+                    <td>dulce.sanchez216759@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244689">
+                    <td>Villegas Sosa, Ramsés Mauricio</td>
+                    <td>00000244689</td>
+                    <td>ramses.villegas244689@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
+                  <tr data-member-id="00000244679">
+                    <td>Viveros Zavala, Angel Gael</td>
+                    <td>00000244679</td>
+                    <td>angel.viveros244679@potros.itson.edu.mx</td>
+                    <td>--</td>
+                    <td>--</td>
+                  </tr>
                 </tbody>
               </table>
             </div>
           </article>
           <script type="application/json" id="pd-members-fallback">
             {
-              "updatedAt": "2025-09-22T18:00:39-07:00",
+              "updatedAt": "2025-09-28T17:00:00-07:00",
               "members": [
                 {
-                  "uid": "in6tomZxWFhMbJ2W89kcVnFjKTx2",
-                  "matricula": "249116",
+                  "id": "00000249116",
+                  "matricula": "00000249116",
                   "displayName": "Arana Guerrero, Danett Itzanami",
                   "email": "danett.arana249116@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:15:11-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "Qff5rjRcvDQrRHMCLRuQRHrUggI2",
-                  "matricula": "147818",
+                  "id": "00000147818",
+                  "matricula": "00000147818",
                   "displayName": "Araujo Godoy, Abraham Francisco",
                   "email": "abraham.araujo@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:08:46-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "tMQg4fl8v0TxZvy6NrYNAzSFWua2",
-                  "matricula": "244228",
+                  "id": "00000244228",
+                  "matricula": "00000244228",
                   "displayName": "Avalos Morales, Egla Icel",
                   "email": "egla.avalos244228@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:02:08-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "qApbgYiBvBf5nuGJwkRfrgdvxaP2",
-                  "matricula": "244442",
+                  "id": "00000244442",
+                  "matricula": "00000244442",
                   "displayName": "Blasco Villagomez, Luis Mario",
                   "email": "luis.blasco244442@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:00:24-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "a5jZkmWDR6YnYbbFGtaSZTQsj8I3",
-                  "matricula": "244242",
+                  "id": "00000244242",
+                  "matricula": "00000244242",
                   "displayName": "Duarte Lopez, Adlemi Guadalupe",
                   "email": "adlemi.duarte244242@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:05:21-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "XovrN93okGeVaT9IqBzLEqAWGfN2",
-                  "matricula": "244473",
+                  "id": "00000244473",
+                  "matricula": "00000244473",
                   "displayName": "Espericueta Ramos, Jesus Alan",
                   "email": "jesus.espericueta244473@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:05:10-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "EbhoRku5IDdSPP3iFCBb5kJ9tCo2",
-                  "matricula": "244608",
+                  "id": "00000244608",
+                  "matricula": "00000244608",
                   "displayName": "Gracia Morales, Sergio Alejandro",
                   "email": "sergio.gracia244608@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:17:14-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "qI5yg45X9SNKC6cNojQRTN4cruZ2",
-                  "matricula": "228847",
+                  "id": "00000228847",
+                  "matricula": "00000228847",
                   "displayName": "Hernandez Gonzalez, Julian Ricardo",
                   "email": "julian.hernandez228847@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:05:56-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "Yzo5O1akFZXpfY4LNbPz10inJVi1",
-                  "matricula": "248997",
+                  "id": "00000248997",
+                  "matricula": "00000248997",
                   "displayName": "Le Blohic Garay, Mario Enrique",
                   "email": "mario.leblohic248997@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:05:33-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "pkVboPZbemSgebTeA4Utkv3aUwI3",
-                  "matricula": "249012",
+                  "id": "00000249012",
+                  "matricula": "00000249012",
                   "displayName": "Lopez Guerrero, Luis Carlos",
                   "email": "luis.lopez249012@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:04:30-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "hC61c739fAeLKJeg7ol6xu6ieq83",
-                  "matricula": "244321",
+                  "id": "00000248990",
+                  "matricula": "00000248990",
+                  "displayName": "Maldonado Montoya, Jose Gabriel",
+                  "email": "jose.maldonado248990@potros.itson.edu.mx",
+                  "updatedAt": null
+                },
+                {
+                  "id": "00000244378",
+                  "matricula": "00000244378",
+                  "displayName": "Martínez Santacruz, Yolanda",
+                  "email": "yolanda.martinez244378@potros.itson.edu.mx",
+                  "updatedAt": null
+                },
+                {
+                  "id": "00000217812",
+                  "matricula": "00000217812",
+                  "displayName": "Martínez Soto, Dainiz Raí",
+                  "email": "dainiz.martinez217812@potros.itson.edu.mx",
+                  "updatedAt": null
+                },
+                {
+                  "id": "00000244321",
+                  "matricula": "00000244321",
                   "displayName": "Nevescanin Moreno, Angel Stipe",
                   "email": "angel.nevescanin244321@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:02:21-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "244477",
-                  "matricula": "244477",
+                  "id": "00000244477",
+                  "matricula": "00000244477",
                   "displayName": "Osuna Aguilera, Erik David",
                   "email": "erik.osuna244477@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-16T19:12:43-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "244711",
-                  "matricula": "244711",
+                  "id": "00000244711",
+                  "matricula": "00000244711",
                   "displayName": "Palacios Cardenas, Jorge Eduardo",
                   "email": "jorge.palacios244711@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-16T09:31:14-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "H1ODGSDs7oUph9PBw6Lg0Jv8Wnw2",
-                  "matricula": "244569",
+                  "id": "00000244569",
+                  "matricula": "00000244569",
                   "displayName": "Preciado Ruiz, Juan Carlos",
                   "email": "juan.preciado244569@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-22T18:00:39-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "244373",
-                  "matricula": "244373",
+                  "id": "00000244373",
+                  "matricula": "00000244373",
                   "displayName": "Reyes Galaz, Jose Abelardo",
                   "email": "jose.reyes244373@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-17T11:53:32-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "nbkqrDn6NBhtUyDQkNqjLppYs0H3",
-                  "matricula": "240691",
+                  "id": "00000240691",
+                  "matricula": "00000240691",
                   "displayName": "Rivas Quintana, Emmanuel",
                   "email": "emmanuel.rivas240691@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:11:45-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "BJpwXy5cdVMPTMVcXPLjiWW06R73",
-                  "matricula": "244266",
+                  "id": "00000244266",
+                  "matricula": "00000244266",
                   "displayName": "Rocha Aguilar, Víctor Emmanuel",
                   "email": "victor.rocha244266@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-22T18:00:10-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "o2cx6nR0o5eqfPW9KNLcACmC7rF3",
-                  "matricula": "244312",
+                  "id": "00000244312",
+                  "matricula": "00000244312",
                   "displayName": "Rodriguez Alvarado, Jose Agustin",
                   "email": "jose.rodriguez244312@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:03:36-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "T2KEeahFMmcnzL909OBJnOUnjJc2",
-                  "matricula": "244621",
+                  "id": "00000244621",
+                  "matricula": "00000244621",
                   "displayName": "Soto Carrazco, Francisco Javier",
                   "email": "francisco.soto244621@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:18:33-07:00"
+                  "updatedAt": null
                 },
                 {
-                  "uid": "qqfwGF092ONfselrklTMkGgTujx1",
-                  "matricula": "244679",
+                  "id": "00000216759",
+                  "matricula": "00000216759",
+                  "displayName": "Sánchez Zavala, Dulce María",
+                  "email": "dulce.sanchez216759@potros.itson.edu.mx",
+                  "updatedAt": null
+                },
+                {
+                  "id": "00000244689",
+                  "matricula": "00000244689",
+                  "displayName": "Villegas Sosa, Ramsés Mauricio",
+                  "email": "ramses.villegas244689@potros.itson.edu.mx",
+                  "updatedAt": null
+                },
+                {
+                  "id": "00000244679",
+                  "matricula": "00000244679",
                   "displayName": "Viveros Zavala, Angel Gael",
                   "email": "angel.viveros244679@potros.itson.edu.mx",
-                  "updatedAt": "2025-09-19T18:08:59-07:00"
+                  "updatedAt": null
                 }
               ]
             }


### PR DESCRIPTION
## Summary
- sync the hard-coded roster in **calificaciones.html** with the attendance list so each student entry matches and is marked as a student
- render the same roster inside the panel docente table and replace the fallback JSON with the updated student list

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9e3bb934c83258d3f3fd10df4d6e7