### PR TITLE
Alinea badge de notificaciones con index

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -208,7 +208,7 @@ function buildRealtimeCenterTemplate() {
     >
       <span class="realtime-toggle__icon" aria-hidden="true">🔔</span>
       <span class="sr-only" data-realtime-toggle-label>Abrir centro de notificaciones</span>
-      <span class="realtime-toggle__badge" data-realtime-badge hidden></span>
+      <span class="realtime-toggle__badge" data-realtime-badge="" hidden=""></span>
     </button>
     <section
       class="realtime-panel"


### PR DESCRIPTION
## Summary
- alinea los atributos del badge de notificaciones en el layout compartido con la versión usada en index para mantener un marcado consistente

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9eba34b2083258ded3b6efa30cdab