### PR TITLE
Fix syntax error in calificaciones uploads user normalization

### DIFF
--- a/js/calificaciones-uploads-ui.js
+++ b/js/calificaciones-uploads-ui.js
@@ -910,10 +910,11 @@ async function handleFileInputChange(event) {
         return "";
       }
     };
-
+    const normalizedAuthUser = {
       uid: normalizeAuthUserField(authUser?.uid),
       email: normalizeAuthUserField(authUser?.email),
       displayName: normalizeAuthUserField(authUser?.displayName),
+    };
 
 
     const extra = {};
@@ -924,9 +925,9 @@ async function handleFileInputChange(event) {
     if (upload.backend) extra.uploadBackend = upload.backend;
     if (upload.path) extra.storagePath = upload.path;
     extra.uploadedBy = {
-      uid: authUser.uid || "",
-      email: authUser.email || "",
-      displayName: authUser.displayName || "",
+      uid: normalizedAuthUser.uid,
+      email: normalizedAuthUser.email,
+      displayName: normalizedAuthUser.displayName,
     };
 
     await createStudentUpload({


### PR DESCRIPTION
## Summary
- define the normalized auth user object literal used when preparing upload metadata
- reuse the normalized auth user values to populate the uploadedBy payload

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da013c1c788325b359e9cb6069f9a1