### PR TITLE
Fix undefined upload reference in evidence upload handler

### DIFF
--- a/js/calificaciones-uploads-ui.js
+++ b/js/calificaciones-uploads-ui.js
@@ -900,6 +900,7 @@ async function handleFileInputChange(event) {
     }
     // authUser presence already validated by getUploadEligibility
 
+    const upload = await uploadEvidenceFile(file, profile.uid);
 
     const normalizeAuthUserField = (value) => {
       if (value == null) return "";


### PR DESCRIPTION
## Summary
- ensure the evidence upload handler retrieves upload metadata before accessing its fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da06e587c48325a4ddf492ad6aa284