### PR TITLE
Move realtime notification toggle to left

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -151,11 +151,11 @@ html.qs-loading body {
 .realtime-center {
   position: fixed;
   bottom: clamp(16px, 4vh, 40px);
-  right: clamp(16px, 3vw, 40px);
+  left: clamp(16px, 3vw, 40px);
   z-index: 1200;
   display: flex;
   flex-direction: column-reverse;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 12px;
   pointer-events: none;
 }
@@ -548,7 +548,7 @@ html.qs-loading body {
 
 @media (max-width: 720px) {
   .realtime-center {
-    right: clamp(12px, 4vw, 20px);
+    left: clamp(12px, 4vw, 20px);
   }
 
   .realtime-panel {

--- a/index.html
+++ b/index.html
@@ -1150,11 +1150,11 @@
       .realtime-center {
         position: fixed;
         bottom: clamp(16px, 4vh, 40px);
-        right: clamp(16px, 3vw, 40px);
+        left: clamp(16px, 3vw, 40px);
         z-index: 1200;
         display: flex;
         flex-direction: column-reverse;
-        align-items: flex-end;
+        align-items: flex-start;
         gap: 12px;
         pointer-events: none;
       }
@@ -1599,7 +1599,7 @@
 
       @media (max-width: 720px) {
         .realtime-center {
-          right: clamp(12px, 4vw, 20px);
+          left: clamp(12px, 4vw, 20px);
         }
 
         .realtime-panel {


### PR DESCRIPTION
## Summary
- position the floating realtime notification toggle on the left edge across the site stylesheet
- mirror the same left-side placement in the inline styles shipped with the index page for consistency on standalone loads

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db0778df7c8325a74001fbbe952121